### PR TITLE
MIN-25: Add CLAUDE.md with CI/CD workflow conventions

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,0 +1,53 @@
+# CLAUDE.md
+
+## CI/CD Workflow Conventions
+
+### Branch Naming
+
+Use `{type}/{issue-identifier-lowercase}` format.
+
+Types: `feat/`, `fix/`, `refactor/`, `chore/`, `docs/`, `test/`
+
+Examples: `feat/min-42`, `fix/min-55`, `chore/min-25-cicd-validation`
+
+### No Direct Pushes to `main`
+
+All changes go through pull requests. Never commit directly to `main`.
+
+### Pull Request Creation
+
+```bash
+gh pr create --title "{ISSUE-ID}: {title}" --body "Resolves [{ISSUE-ID}](https://paperclip.ing/MIN/issues/{ISSUE-ID})"
+```
+
+### CI Monitoring
+
+After pushing, verify CI passes:
+
+```bash
+gh pr checks
+```
+
+On failure, read logs and fix:
+
+```bash
+gh run view --log-failed
+```
+
+Fix the issue and re-push. Cap at 3 attempts before marking the Paperclip issue as `blocked`.
+
+### Merge
+
+When the issue is complete and CI passes, squash-merge:
+
+```bash
+gh pr merge --squash --delete-branch
+```
+
+### Commit Co-Author
+
+All commits must include:
+
+```
+Co-Authored-By: Paperclip <noreply@paperclip.ing>
+```


### PR DESCRIPTION
## Summary

- Adds `CLAUDE.md` with CI/CD workflow conventions for agent-managed pipelines
- Defines branch naming, PR creation, CI monitoring, merge strategy, and commit co-author rules
- Validates end-to-end CI/CD workflow (branch → PR → CI → merge)

Resolves [MIN-25](/MIN/issues/MIN-25)