### PR TITLE
MIN-32: Add architecture docs and marketing interface directory

### DIFF
--- a/.github/workflows/ci-build.yml
+++ b/.github/workflows/ci-build.yml
@@ -9,6 +9,9 @@ on:
       - 'src/**'
       - 'Cargo.toml'
       - 'Cargo.lock'
+      - 'docs/**'
+      - 'marketing/**'
+      - 'README.md'
   push:
     branches:
       - main

--- a/README.md
+++ b/README.md
@@ -46,7 +46,7 @@ minecraft-map-factory-pipeline --config pipeline.toml --dry-run
 minecraft-map-factory-pipeline --config pipeline.toml --json-logs
 ```
 
-See [docs/pipeline-operations.md](docs/pipeline-operations.md) for full pipeline operations documentation.
+See [docs/pipeline-operations.md](docs/pipeline-operations.md) for full pipeline operations documentation and [docs/architecture.md](docs/architecture.md) for the system architecture overview.
 
 ### Run the GUI (Arnis)
 
@@ -67,7 +67,8 @@ cargo run --no-default-features -- \
 minecraft-map-factory/
   src/              # Arnis core -- map generation engine
   pipeline/         # Autonomous pipeline (scheduler, generator, validator, publisher)
-  docs/             # Operations documentation
+  docs/             # Architecture and operations documentation
+  marketing/        # Map request templates and output format guides
   assets/           # GUI and documentation assets
   tests/            # Integration tests
 ```

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -1,0 +1,119 @@
+# System Architecture
+
+Minecraft Map Factory transforms real-world geographic data into playable Minecraft worlds through a multi-stage pipeline. This document describes the system components, data flow, and how they fit together.
+
+## Components
+
+### Arnis Core (`src/`)
+
+The map generation engine. Converts OpenStreetMap geographic data into Minecraft Java Edition (1.17+) and Bedrock Edition worlds. Key subsystems:
+
+- **OSM Parser** -- fetches and parses OpenStreetMap data for a bounding box
+- **Element Processing** -- converts OSM elements (buildings, roads, water, vegetation) into Minecraft block types
+- **Elevation** -- processes terrain height data for realistic topography
+- **Entity Placement** -- spawns appropriate Minecraft entities within generated areas
+- **World Editor** -- writes Minecraft Anvil region files (`.mca`) to disk
+- **Coordinate System** -- translates geographic coordinates (lat/lng) to Minecraft block coordinates
+
+### Pipeline (`pipeline/`)
+
+An autonomous batch processor that schedules, generates, validates, and publishes maps at scale. Comprised of four stages described below.
+
+### Locations Database (`pipeline/data/locations.toml`)
+
+A TOML file defining target areas for map generation. Each entry includes a human-readable name, geographic bounding box, size tier, and optional tags. The pipeline processes locations in tier order: small first, then medium, then large.
+
+Example entry:
+
+```toml
+[[location]]
+name = "Times Square, NYC"
+state = "NY"
+bbox = [40.7565, -73.9882, 40.7600, -73.9842]
+tier = "small"
+tags = ["landmark", "urban"]
+```
+
+## Pipeline Stages
+
+### 1. Scheduler
+
+The orchestrator. Reads the locations database, prioritizes by tier, and dispatches concurrent generation jobs. Enforces resource limits defined in `pipeline.toml`:
+
+- `scheduler.max_concurrency` -- parallel job limit (default: half of available CPUs)
+- `scheduler.max_memory_mb` -- RSS memory threshold before throttling
+- `scheduler.max_cpu_percent` -- CPU usage threshold
+
+Between jobs, a self-tuner monitors success rates and resource usage. If the success rate drops below `tuning.min_success_rate` or memory exceeds `tuning.memory_threshold`, concurrency is automatically reduced (minimum of 1).
+
+### 2. Generator
+
+Invokes the Arnis core binary for each location with bounding-box parameters. Output lands in `{output_dir}/jobs/{location_name}_attempt{N}/`.
+
+Failures are classified and handled by the retry strategy:
+
+| Error Type | Behavior |
+|------------|----------|
+| **Transient** (timeout, HTTP 429/503) | Retry with exponential backoff (configured via `retry.initial_backoff_secs` and `retry.max_backoff_secs`) |
+| **Resource** (OOM, disk full) | Shrink bounding box by `retry.bbox_shrink_factor` and retry |
+| **Permanent** (invalid coordinates) | Fail immediately, no retry |
+
+Maximum attempts per job: `retry.max_retries` (default: 3).
+
+### 3. Validator
+
+Checks generated map integrity before publishing:
+
+- **Region file count** -- at least `validation.min_region_files` `.mca` files present
+- **Total output size** -- meets `validation.min_map_size_bytes` threshold
+- **Anvil structure** -- each `.mca` file is at least 8 KB with valid Anvil format headers (when `validation.validate_structure` is enabled)
+
+Maps that fail validation are marked as failed with specific failure reasons.
+
+### 4. Publisher
+
+Copies validated maps to their final location at `{output_dir}/published/{sanitized_name}/`. Location names are sanitized to alphanumeric characters and dashes. If a previous output exists for that location, it is replaced.
+
+## Data Flow
+
+```
+locations.toml
+      |
+      v
+  Scheduler ──── Self-Tuner
+      |               |
+      v               |
+  Generator ←── Retry Strategy
+      |
+      v
+  Validator
+      |
+      v
+  Publisher ──→ {output_dir}/published/{location_name}/
+      |
+      v
+  Metrics Collector
+```
+
+1. The **Scheduler** reads locations from `locations.toml` and dispatches jobs in tier order
+2. The **Generator** invokes the Arnis binary, producing raw Minecraft world files in `jobs/`
+3. The **Validator** checks region file count, size, and Anvil structure
+4. The **Publisher** copies validated output to `published/` for consumption
+5. The **Metrics Collector** records duration, output size, and success/failure for each job
+
+## Output Locations
+
+All paths are relative to the `output_dir` setting in `pipeline.toml`:
+
+| Path | Contents |
+|------|----------|
+| `jobs/{name}_attempt{N}/` | Raw generator output per attempt |
+| `published/{name}/` | Validated, ready-to-use Minecraft worlds |
+
+## Configuration
+
+Runtime behavior is controlled by `pipeline.toml`. See [pipeline-operations.md](pipeline-operations.md) for the full configuration reference, CLI overrides, and operational guidance.
+
+## Metrics and Observability
+
+The pipeline tracks per-job metrics (duration, output size, success/failure) and prints periodic summaries with p50/p95/p99 duration percentiles and failure breakdowns. Use `--json-logs` for structured output suitable for log aggregation. See [pipeline-operations.md](pipeline-operations.md) for details.

--- a/marketing/MAP_REQUEST_TEMPLATE.md
+++ b/marketing/MAP_REQUEST_TEMPLATE.md
@@ -1,0 +1,60 @@
+# Map Request Template
+
+Fill out the fields below to request a new Minecraft map generation.
+
+## Required Fields
+
+### Location Name
+
+A descriptive, human-readable name for the area.
+
+> Example: "Times Square, NYC"
+
+**Your location:** _____
+
+### Bounding Box
+
+Geographic coordinates defining the area to generate, as four decimal values: minimum latitude, minimum longitude, maximum latitude, maximum longitude.
+
+Use [bboxfinder.com](http://bboxfinder.com) or a similar tool to determine coordinates.
+
+> Example: 40.7565, -73.9882, 40.7600, -73.9842
+
+| Field | Value |
+|-------|-------|
+| Min Latitude | |
+| Min Longitude | |
+| Max Latitude | |
+| Max Longitude | |
+
+### Priority Tier
+
+How large is the requested area? This determines processing order.
+
+- [ ] **Small** -- single landmark, intersection, or small park
+- [ ] **Medium** -- neighborhood, campus, or district
+- [ ] **Large** -- downtown area, waterfront, or multiple city blocks
+
+## Optional Fields
+
+### State / Region
+
+US state abbreviation or region name.
+
+> Example: "NY"
+
+**State/Region:** _____
+
+### Tags
+
+Descriptive categories for the location (comma-separated).
+
+> Example: landmark, urban, tourist
+
+**Tags:** _____
+
+### Notes
+
+Any special considerations: areas to emphasize, known geographic features, time constraints, or intended use.
+
+**Notes:** _____

--- a/marketing/OUTPUT_FORMAT.md
+++ b/marketing/OUTPUT_FORMAT.md
@@ -1,0 +1,69 @@
+# Output Format
+
+This document describes the structure and format of published Minecraft maps produced by the pipeline.
+
+## Published Map Location
+
+Completed maps are placed in the pipeline's published output directory:
+
+```
+{output_dir}/published/{location_name}/
+```
+
+Each location gets its own folder. The location name is sanitized to contain only alphanumeric characters and dashes (spaces and special characters are replaced with underscores).
+
+## File Structure
+
+Each published map is a standard Minecraft world folder containing Anvil region files:
+
+```
+published/times-square-nyc/
+  region/
+    r.0.0.mca
+    r.0.-1.mca
+    r.-1.0.mca
+    ...
+```
+
+### Region Files (`.mca`)
+
+Region files use Minecraft's Anvil format. Each `.mca` file contains a 32x32 grid of chunks (512x512 blocks). Key characteristics:
+
+- Minimum file size: 8 KB (two 4096-byte lookup tables)
+- Named by region coordinates: `r.{x}.{z}.mca`
+- Compatible with Minecraft Java Edition 1.17+
+
+The number of region files depends on the size of the requested bounding box. A small landmark may produce 1-2 region files; a large downtown area may produce dozens.
+
+## Using Generated Maps
+
+### Minecraft Java Edition
+
+Copy the published location folder into your Minecraft saves directory:
+
+```
+# macOS
+~/Library/Application Support/minecraft/saves/
+
+# Windows
+%APPDATA%\.minecraft\saves\
+
+# Linux
+~/.minecraft/saves/
+```
+
+The folder will appear as a selectable world in the Minecraft launcher.
+
+### Minecraft Bedrock Edition
+
+Bedrock Edition worlds require conversion from the Java Edition Anvil format. The generated maps are in Java Edition format by default.
+
+## Quality Guarantees
+
+Every published map has passed the pipeline's validation checks:
+
+- At least one valid `.mca` region file is present
+- Total output meets the minimum size threshold
+- Each region file has valid Anvil format headers (when structure validation is enabled)
+
+Maps that fail any validation check are not published. If a requested map is not present in the published output, it did not pass validation and may need to be re-requested with adjusted parameters (e.g., a smaller bounding box).

--- a/marketing/README.md
+++ b/marketing/README.md
@@ -1,0 +1,49 @@
+# Marketing Interface
+
+This directory contains documentation for requesting and receiving generated Minecraft maps. No code or build artifacts belong here.
+
+## How Map Generation Works
+
+Minecraft Map Factory converts real-world locations into playable Minecraft worlds. You provide a location and bounding box, the pipeline generates the map, and you receive a ready-to-use Minecraft world folder.
+
+## Request-to-Delivery Workflow
+
+### 1. Submit a Map Request
+
+Fill out the [Map Request Template](MAP_REQUEST_TEMPLATE.md) with your desired location, bounding box coordinates, priority tier, and any special notes. Submit the completed request to the engineering team.
+
+### 2. Location Added to Database
+
+Engineering adds your location to the pipeline's locations database. Each location gets a name, geographic bounding box, and a size tier (small, medium, or large) that determines processing priority.
+
+### 3. Pipeline Processes the Request
+
+The automated pipeline handles everything from here:
+
+- **Scheduling** -- your location is queued by tier (small locations process first)
+- **Generation** -- real-world geographic data is fetched and converted into Minecraft blocks, terrain, and entities
+- **Validation** -- the generated world is checked for completeness and structural integrity
+- **Publishing** -- validated maps are placed in the published output directory
+
+### 4. Receive Your Map
+
+Once published, your map is available as a standard Minecraft world folder. See [Output Format](OUTPUT_FORMAT.md) for details on the file structure and how to use the generated maps.
+
+## Turnaround
+
+Processing time depends on the size of the requested area:
+
+| Tier | Typical Area | Processing |
+|------|-------------|------------|
+| Small | Single landmark or intersection | Minutes |
+| Medium | Neighborhood or district | Minutes to hours |
+| Large | Downtown area or multiple blocks | Hours |
+
+The pipeline processes multiple locations concurrently. Actual times depend on server load and queue depth.
+
+## Files in This Directory
+
+| File | Purpose |
+|------|---------|
+| [MAP_REQUEST_TEMPLATE.md](MAP_REQUEST_TEMPLATE.md) | Template for submitting new map requests |
+| [OUTPUT_FORMAT.md](OUTPUT_FORMAT.md) | Description of published map file structure and usage |


### PR DESCRIPTION
Resolves [MIN-32](https://cirruslycloudy.com/MIN/issues/MIN-32)

## Summary
- Created `docs/architecture.md` — system overview, pipeline stages, data flow diagram, output locations, and config references
- Created `marketing/README.md` — end-to-end request-to-delivery workflow for non-technical stakeholders
- Created `marketing/MAP_REQUEST_TEMPLATE.md` — structured template with required fields (location name, bounding box, priority tier) and optional fields (state, tags, notes)
- Created `marketing/OUTPUT_FORMAT.md` — published map file structure, Anvil format details, and usage instructions
- Updated top-level `README.md` to reference architecture doc and marketing directory

## Test plan
- [ ] Verify all markdown renders correctly on GitHub
- [ ] Confirm links between docs resolve properly
- [ ] Review accuracy of pipeline stage descriptions against source code

🤖 Generated with [Claude Code](https://claude.com/claude-code)
