### PR TITLE
MIN-24: Document pipeline schedule, automation, and dev/marketing workflow

### DIFF
--- a/README.md
+++ b/README.md
@@ -46,7 +46,7 @@ minecraft-map-factory-pipeline --config pipeline.toml --dry-run
 minecraft-map-factory-pipeline --config pipeline.toml --json-logs
 ```
 
-See [docs/pipeline-operations.md](docs/pipeline-operations.md) for full pipeline operations documentation and [docs/architecture.md](docs/architecture.md) for the system architecture overview.
+See [docs/pipeline-operations.md](docs/pipeline-operations.md) for full pipeline operations documentation, [docs/architecture.md](docs/architecture.md) for the system architecture overview (including the twice-daily CI schedule and auto-commit flow), and [marketing/WORKFLOW.md](marketing/WORKFLOW.md) for the dev ↔ marketing handoff contract.
 
 ### Run the GUI (Arnis)
 

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -103,12 +103,41 @@ locations.toml
 
 ## Output Locations
 
-All paths are relative to the `output_dir` setting in `pipeline.toml`:
+All paths are relative to the `output_dir` setting in `pipeline.toml`. In the scheduled CI run, `output_dir` is `pipeline/output/`, so the canonical, repo-relative paths are:
 
 | Path | Contents |
 |------|----------|
-| `jobs/{name}_attempt{N}/` | Raw generator output per attempt |
-| `published/{name}/` | Validated, ready-to-use Minecraft worlds |
+| `pipeline/output/jobs/{name}_attempt{N}/` | Raw generator output per attempt |
+| `pipeline/output/published/{name}/` | Validated, ready-to-use Minecraft worlds |
+
+Validated, published worlds are auto-committed back to `main` by the commit-output workflow (see Automation & Scheduling), so anyone with repo access can `git pull` to retrieve the latest map set.
+
+## Automation & Scheduling
+
+The pipeline does not need to be invoked by hand. GitHub Actions drives the full cycle:
+
+| Workflow | File | Trigger | Purpose |
+|----------|------|---------|---------|
+| **Scheduled Pipeline** | `.github/workflows/scheduled-pipeline.yml` | Cron `1 0 * * *` and `1 12 * * *` (UTC) — twice daily at 00:01 and 12:01 UTC; also `workflow_dispatch` | Build the pipeline in release mode, run it against `pipeline/data/locations.toml`, and upload `pipeline/output/` as a 30-day artifact |
+| **Commit Output Artifacts** | `.github/workflows/commit-output.yml` | `workflow_dispatch` (input: `output-path`) | Stage and commit any new files under the given output path with a metadata-aware message, then push to `main` |
+| **CI Build** | `.github/workflows/ci-build.yml` | Pull requests touching code/docs/marketing, plus push to `main` | Lint, test, and validate changes before merge |
+
+End-to-end automated flow:
+
+```
+00:01 UTC / 12:01 UTC          (cron)
+  └─► scheduled-pipeline.yml
+        └─► cargo build --release -p minecraft-map-factory-pipeline
+        └─► run pipeline → pipeline/output/published/{location}/
+        └─► upload-artifact (pipeline-output, 30d retention)
+
+manual / follow-up
+  └─► commit-output.yml  (workflow_dispatch with output-path)
+        └─► git add pipeline/output/...
+        └─► git commit && git push   → main
+```
+
+Concurrency is gated by `concurrency: scheduled-pipeline` so two scheduled runs never overlap. If you need an off-schedule run, dispatch the workflow manually from the GitHub Actions tab.
 
 ## Configuration
 

--- a/docs/pipeline-operations.md
+++ b/docs/pipeline-operations.md
@@ -144,6 +144,29 @@ When enabled, the self-tuner monitors success rate and resource usage between jo
 - If memory usage exceeds `memory_threshold` (default: 80%), concurrency is reduced
 - Concurrency never drops below 1
 
+## Scheduled Runs (CI)
+
+In production, the pipeline runs unattended on GitHub Actions. The `Scheduled Pipeline` workflow (`.github/workflows/scheduled-pipeline.yml`) fires on two cron triggers:
+
+| Cron | UTC | Description |
+|------|-----|-------------|
+| `1 0 * * *` | 00:01 | Nightly run |
+| `1 12 * * *` | 12:01 | Mid-day run |
+
+Each run executes:
+
+```bash
+cargo build --release -p minecraft-map-factory-pipeline
+./target/release/minecraft-map-factory-pipeline \
+  --config pipeline/pipeline.toml \
+  --output-dir pipeline/output \
+  --json-logs
+```
+
+Outputs are uploaded as the `pipeline-output` artifact (30-day retention). To persist published maps in the repo, dispatch the `Commit Output Artifacts` workflow with `output-path: pipeline/output/published`. That workflow stages new files, generates a metadata-aware commit message, and pushes to `main`.
+
+You can trigger an off-schedule run any time from the Actions tab using `workflow_dispatch`. Concurrency is constrained so two scheduled runs never overlap.
+
 ## Running End-to-End
 
 1. **Prepare locations** -- create a `locations.toml` with your target areas

--- a/marketing/README.md
+++ b/marketing/README.md
@@ -1,33 +1,40 @@
 # Marketing Interface
 
-This directory contains documentation for requesting and receiving generated Minecraft maps. No code or build artifacts belong here.
+This directory is the contract between Minecraft Map Factory (the dev shop) and the marketing partner. It contains everything needed to request, receive, and monetize generated Minecraft maps. No code or build artifacts belong here.
+
+For the full automation contract — schedule, delivery channels, and failure handling — see **[WORKFLOW.md](WORKFLOW.md)**.
 
 ## How Map Generation Works
 
-Minecraft Map Factory converts real-world locations into playable Minecraft worlds. You provide a location and bounding box, the pipeline generates the map, and you receive a ready-to-use Minecraft world folder.
+Minecraft Map Factory converts real-world locations into playable Minecraft worlds. You provide a location and bounding box, the pipeline generates the map twice a day on GitHub Actions, and you receive a ready-to-use Minecraft world folder either as a CI artifact or committed to the repo.
 
 ## Request-to-Delivery Workflow
 
 ### 1. Submit a Map Request
 
-Fill out the [Map Request Template](MAP_REQUEST_TEMPLATE.md) with your desired location, bounding box coordinates, priority tier, and any special notes. Submit the completed request to the engineering team.
+Open a GitHub issue against this repo using the [Map Request Template](MAP_REQUEST_TEMPLATE.md): desired location, bounding box, priority tier, and any special notes.
 
 ### 2. Location Added to Database
 
-Engineering adds your location to the pipeline's locations database. Each location gets a name, geographic bounding box, and a size tier (small, medium, or large) that determines processing priority.
+Engineering merges a PR that appends your location to `pipeline/data/locations.toml`. Each location gets a name, bounding box, and tier (small, medium, or large) that determines processing priority.
 
 ### 3. Pipeline Processes the Request
 
-The automated pipeline handles everything from here:
+The pipeline runs on a fixed schedule — **00:01 UTC and 12:01 UTC daily** — via the `Scheduled Pipeline` GitHub Actions workflow. Each run:
 
-- **Scheduling** -- your location is queued by tier (small locations process first)
-- **Generation** -- real-world geographic data is fetched and converted into Minecraft blocks, terrain, and entities
-- **Validation** -- the generated world is checked for completeness and structural integrity
-- **Publishing** -- validated maps are placed in the published output directory
+- **Schedules** locations by tier (small first, then medium, then large)
+- **Generates** worlds from OpenStreetMap data with terrain, buildings, and entities
+- **Validates** completeness and structural integrity
+- **Publishes** validated maps to `pipeline/output/published/{name}/`
 
 ### 4. Receive Your Map
 
-Once published, your map is available as a standard Minecraft world folder. See [Output Format](OUTPUT_FORMAT.md) for details on the file structure and how to use the generated maps.
+Two delivery channels are available:
+
+- **CI artifact** — every scheduled run uploads `pipeline-output` to GitHub Actions (30-day retention). Best for previewing a single run.
+- **Repo (canonical for monetization)** — after the `Commit Output Artifacts` workflow runs, the published maps are committed to `main`. `git pull` to retrieve them.
+
+See [OUTPUT_FORMAT.md](OUTPUT_FORMAT.md) for the file structure and how to use the worlds.
 
 ## Turnaround
 
@@ -45,5 +52,6 @@ The pipeline processes multiple locations concurrently. Actual times depend on s
 
 | File | Purpose |
 |------|---------|
+| [WORKFLOW.md](WORKFLOW.md) | Full dev ↔ marketing contract: schedule, delivery, failure handling |
 | [MAP_REQUEST_TEMPLATE.md](MAP_REQUEST_TEMPLATE.md) | Template for submitting new map requests |
 | [OUTPUT_FORMAT.md](OUTPUT_FORMAT.md) | Description of published map file structure and usage |

--- a/marketing/WORKFLOW.md
+++ b/marketing/WORKFLOW.md
@@ -1,0 +1,127 @@
+# Dev ↔ Marketing Automated Workflow
+
+This document defines the contract between Minecraft Map Factory (the dev shop) and the marketing partner. The handoff is intentionally narrow so both sides can run independently and asynchronously.
+
+## Roles
+
+| Role | Owner | Responsibilities |
+|------|-------|------------------|
+| **Marketing** | external partner | Researches in-demand locations, files map requests, distributes and monetizes the published outputs |
+| **Engineering** | this repo | Maintains the pipeline, accepts requests via `pipeline/data/locations.toml`, and publishes validated worlds |
+| **Pipeline** | GitHub Actions | Generates and validates maps on a fixed schedule, no manual coordination needed |
+
+## End-to-End Flow
+
+```
+Marketing research
+        │
+        ▼
+GitHub issue (Map Request)         ──►  filed against this repo using
+        │                               marketing/MAP_REQUEST_TEMPLATE.md
+        ▼
+Engineering adds entry to
+pipeline/data/locations.toml       ──►  one PR per batch of new locations
+        │
+        ▼
+Scheduled Pipeline (cron)          ──►  runs at 00:01 and 12:01 UTC daily
+        │                               (.github/workflows/scheduled-pipeline.yml)
+        ▼
+Validated worlds land in
+pipeline/output/published/{name}/  ──►  Anvil region files, Java Edition 1.17+
+        │
+        ▼
+Commit Output Artifacts            ──►  pushes published maps to main
+(workflow_dispatch)                     (.github/workflows/commit-output.yml)
+        │
+        ▼
+Marketing pulls / monetizes        ──►  `git pull` to fetch the new worlds,
+                                        upload to distribution channels
+```
+
+## Inputs (Marketing → Engineering)
+
+### 1. File a Map Request
+
+Open a GitHub issue in this repo using the `marketing/MAP_REQUEST_TEMPLATE.md` template. Required fields:
+
+- **Location name** — human-readable (e.g., "Times Square, NYC")
+- **Bounding box** — `min_lat, min_lng, max_lat, max_lng`
+- **Tier** — `small`, `medium`, or `large`
+
+Optional fields: state/region, tags, and notes (any constraints engineering should know).
+
+### 2. Batch and Track
+
+Marketing can submit requests one at a time or in batches. Engineering groups them into a PR that appends new entries to `pipeline/data/locations.toml`. The next scheduled run picks them up automatically.
+
+### 3. SLA
+
+| Tier | Typical area | Generation time |
+|------|--------------|-----------------|
+| Small | Single landmark or intersection | Minutes |
+| Medium | Neighborhood or district | Minutes to hours |
+| Large | Downtown area or multiple blocks | Hours |
+
+Times are per-job and depend on CI capacity. The pipeline runs at 00:01 and 12:01 UTC, so a request merged before 23:00 UTC will normally appear in the next morning's output.
+
+## Outputs (Engineering → Marketing)
+
+### 1. Where Maps Live
+
+Validated worlds are written to:
+
+```
+pipeline/output/published/{sanitized_location_name}/
+```
+
+Inside each location folder you'll find a Minecraft world directory with:
+
+```
+{location}/
+  region/
+    r.0.0.mca
+    r.0.-1.mca
+    ...
+```
+
+Names are sanitized to alphanumeric characters and dashes. See [OUTPUT_FORMAT.md](OUTPUT_FORMAT.md) for the complete file structure.
+
+### 2. How Marketing Pulls Outputs
+
+Two delivery channels are supported:
+
+1. **Repo (default for monetization)** — once the `Commit Output Artifacts` workflow has been dispatched against the latest pipeline run, the published maps are committed to `main`. Marketing clones or pulls the repo and reads from `pipeline/output/published/`. This is the canonical path for monetizable deliverables because it carries Git history.
+2. **CI artifact (transient)** — every scheduled run also uploads `pipeline-output` to GitHub Actions with 30-day retention. Useful for previewing a single run without waiting for the commit.
+
+### 3. Quality Guarantees
+
+Every map under `pipeline/output/published/` has passed pipeline validation:
+
+- ≥1 valid `.mca` region file
+- Total output ≥ `validation.min_map_size_bytes` (default 1024)
+- Each `.mca` ≥ 8 KB with valid Anvil headers (when `validate_structure` is enabled)
+
+If a requested location is not present in `published/`, it failed validation and should be re-requested with adjusted parameters (typically a smaller bounding box).
+
+## Failure Handling
+
+| Symptom | Owner | Action |
+|---------|-------|--------|
+| Request not in `published/` after the next scheduled run | Engineering | Inspect pipeline logs for the location, classify the failure, retry with a tighter bbox if needed |
+| Marketing-reported quality issue (missing buildings, wrong terrain) | Engineering | Open an issue against the responsible work stream (e.g., terrain integrity, interiors). Reference the affected location |
+| Schedule miss (no run at the expected window) | Engineering | Check the `Scheduled Pipeline` workflow status on the Actions tab; rerun via `workflow_dispatch` |
+| Commit-output workflow not dispatched | Engineering | Run it manually with `output-path: pipeline/output/published` |
+
+## Files in This Directory
+
+| File | Purpose |
+|------|---------|
+| [README.md](README.md) | High-level overview of the marketing interface |
+| [MAP_REQUEST_TEMPLATE.md](MAP_REQUEST_TEMPLATE.md) | Template marketing fills out per request |
+| [OUTPUT_FORMAT.md](OUTPUT_FORMAT.md) | Specification of published map files |
+| [WORKFLOW.md](WORKFLOW.md) | This document — the dev ↔ marketing contract |
+
+## Related Engineering Docs
+
+- [Architecture](../docs/architecture.md) — system components, data flow, automation
+- [Pipeline operations](../docs/pipeline-operations.md) — configuration, scheduled runs, observability


### PR DESCRIPTION
## Summary

Closes the documentation gaps called out in MIN-24:

- **When does the pipeline run?** Documents the twice-daily cron schedule (00:01 and 12:01 UTC) in both `docs/architecture.md` and `docs/pipeline-operations.md`, including the GitHub Actions workflows (`scheduled-pipeline.yml`, `commit-output.yml`, `ci-build.yml`).
- **Where do maps live?** Adds the canonical repo-relative path (`pipeline/output/published/`) to the architecture doc and explains both delivery channels (CI artifact + git commit on `main`).
- **Dev ↔ marketing contract.** Adds `marketing/WORKFLOW.md` with the full automated handoff: how requests are filed, how they enter `pipeline/data/locations.toml`, when the pipeline picks them up, where outputs land, and how marketing pulls them. Tightens `marketing/README.md` to point at the new contract.
- Cross-links everything from the top-level `README.md`.

No code changes — docs only.

## Test plan

- [ ] Render the four updated docs in GitHub and confirm cross-links resolve
- [ ] Confirm the cron values in `docs/pipeline-operations.md` match `.github/workflows/scheduled-pipeline.yml`
- [ ] Confirm the `pipeline/output/published/` path matches `pipeline/pipeline.toml`'s `output_dir`