### PR TITLE
MIN-44: Resolve config file paths relative to config file directory

### DIFF
--- a/pipeline/src/config.rs
+++ b/pipeline/src/config.rs
@@ -406,7 +406,17 @@ impl PipelineConfig {
         path: &std::path::Path,
     ) -> Result<Self, Box<dyn std::error::Error + Send + Sync>> {
         let content = std::fs::read_to_string(path)?;
-        let config: Self = toml::from_str(&content)?;
+        let mut config: Self = toml::from_str(&content)?;
+        // Resolve relative paths relative to the config file's directory so
+        // the pipeline can be invoked from any working directory.
+        if let Some(base) = path.parent() {
+            if config.locations_file.is_relative() {
+                config.locations_file = base.join(&config.locations_file);
+            }
+            if config.arnis_binary.is_relative() {
+                config.arnis_binary = base.join(&config.arnis_binary);
+            }
+        }
         Ok(config)
     }
 }


### PR DESCRIPTION
Resolves [MIN-44](/MIN/issues/MIN-44)

## Root cause

`PipelineConfig::from_file()` deserialized `locations_file` and `arnis_binary` as raw strings and resolved them relative to the process CWD. Running the pipeline from the repo root with `--config pipeline/pipeline.toml` (as the scheduled-pipeline workflow does) made `data/locations.toml` unreachable (NotFound) and pointed `arnis_binary` to the wrong location.

## Fix

Resolve relative paths against the config file's parent directory in `from_file()`. When invoked from within `pipeline/` with `--config pipeline.toml`, the empty parent resolves identically to CWD-relative — existing local dev behaviour is unchanged.

## Note

A second fix is still needed: the scheduled-pipeline workflow must build all workspace members (`cargo build --release`) instead of only the pipeline orchestrator (`cargo build --release -p minecraft-map-factory-pipeline`) so the map generator binary exists before the pipeline spawns it. That workflow change requires the `workflow` PAT scope — pending jdogrocks.