### PR TITLE
MIN-134: Add outdoor entity placement, Colorado tree infill, dog-park wolves

### DIFF
--- a/pipeline/src/validator/region_size.rs
+++ b/pipeline/src/validator/region_size.rs
@@ -33,7 +33,10 @@ mod tests {
         // All of these previously false-positived on sparse-terrain maps.
         for size in [4_202_496, 4_200_000, 100, 7_753_728, 12_000_000] {
             let reasons = check(&cfg, &[rf("r.0.0.mca", size)]);
-            assert!(reasons.is_empty(), "size {size} produced reasons: {reasons:?}");
+            assert!(
+                reasons.is_empty(),
+                "size {size} produced reasons: {reasons:?}"
+            );
         }
     }
 }

--- a/src/element_processing/buildings.rs
+++ b/src/element_processing/buildings.rs
@@ -3953,6 +3953,23 @@ pub fn generate_buildings(
                 );
             }
         }
+
+        // P1: Outdoor entity placement for residential yards (0–2 per house)
+        if args.entities
+            && matches!(
+                category,
+                BuildingCategory::House | BuildingCategory::Residential
+            )
+        {
+            let yard_positions: Vec<(i32, i32)> =
+                element.nodes.iter().map(|n| (n.x, n.z)).collect();
+            crate::entity_placement::place_outdoor_entities(
+                editor,
+                &yard_positions,
+                crate::entity_placement::OutdoorContext::ResidentialYard,
+                element.id,
+            );
+        }
     }
 
     // Process roof generation using style decisions

--- a/src/element_processing/highways.rs
+++ b/src/element_processing/highways.rs
@@ -1051,6 +1051,25 @@ fn generate_highways_internal(
                 }
                 previous_node = Some((node.x, node.z));
             }
+
+            // P1: Outdoor entity placement along footways and paths (~1 per 8 blocks)
+            if args.entities && matches!(highway_type.as_str(), "footway" | "path") {
+                let mut all_pts: Vec<(i32, i32)> = Vec::new();
+                let mut prev_fp: Option<(i32, i32)> = None;
+                for node in &way.nodes {
+                    if let Some((px, pz)) = prev_fp {
+                        let pts = bresenham_line(px, 0, pz, node.x, 0, node.z);
+                        all_pts.extend(pts.iter().map(|&(bx, _, bz)| (bx, bz)));
+                    }
+                    prev_fp = Some((node.x, node.z));
+                }
+                crate::entity_placement::place_outdoor_entities(
+                    editor,
+                    &all_pts,
+                    crate::entity_placement::OutdoorContext::Footway,
+                    way.id,
+                );
+            }
         }
     }
 }

--- a/src/element_processing/leisure.rs
+++ b/src/element_processing/leisure.rs
@@ -84,10 +84,7 @@ pub fn generate_leisure(
 
             // P1: Outdoor entity placement for park areas (~1 per 15 cells)
             if args.entities
-                && matches!(
-                    leisure_type.as_str(),
-                    "park" | "garden" | "nature_reserve"
-                )
+                && matches!(leisure_type.as_str(), "park" | "garden" | "nature_reserve")
             {
                 crate::entity_placement::place_outdoor_entities(
                     editor,

--- a/src/element_processing/leisure.rs
+++ b/src/element_processing/leisure.rs
@@ -82,6 +82,21 @@ pub fn generate_leisure(
         if corner_addup != (0, 0, 0) {
             let filled_area = flood_fill_cache.get_or_compute(element, args.timeout.as_ref());
 
+            // P1: Outdoor entity placement for park areas (~1 per 15 cells)
+            if args.entities
+                && matches!(
+                    leisure_type.as_str(),
+                    "park" | "garden" | "nature_reserve"
+                )
+            {
+                crate::entity_placement::place_outdoor_entities(
+                    editor,
+                    &filled_area,
+                    crate::entity_placement::OutdoorContext::Park,
+                    element.id,
+                );
+            }
+
             // Use deterministic RNG seeded by element ID for consistent results across region boundaries
             let mut rng = element_rng(element.id);
 
@@ -120,6 +135,13 @@ pub fn generate_leisure(
                             Tree::create(editor, (x, 1, z), Some(building_footprints));
                         }
                         _ => {}
+                    }
+                }
+
+                // P3: Dog park wolf spawning (~1-in-6 per cell)
+                if args.entities && leisure_type == "dog_park" {
+                    if rng.random_range(0..6) == 0 {
+                        editor.add_entity("minecraft:wolf", x, 1, z, None);
                     }
                 }
 

--- a/src/element_processing/leisure.rs
+++ b/src/element_processing/leisure.rs
@@ -136,10 +136,8 @@ pub fn generate_leisure(
                 }
 
                 // P3: Dog park wolf spawning (~1-in-6 per cell)
-                if args.entities && leisure_type == "dog_park" {
-                    if rng.random_range(0..6) == 0 {
-                        editor.add_entity("minecraft:wolf", x, 1, z, None);
-                    }
+                if args.entities && leisure_type == "dog_park" && rng.random_range(0..6) == 0 {
+                    editor.add_entity("minecraft:wolf", x, 1, z, None);
                 }
 
                 // Add playground or recreation ground features

--- a/src/entity_placement/mod.rs
+++ b/src/entity_placement/mod.rs
@@ -4,6 +4,74 @@ use crate::element_processing::buildings::BuildingCategory;
 use crate::world_editor::WorldEditor;
 use theme::ThemePack;
 
+/// Context for outdoor entity placement, determining entity types and density.
+#[derive(Copy, Clone)]
+pub enum OutdoorContext {
+    /// Open park / garden / nature_reserve areas: wolves (w=40), cats (w=30), villagers (w=30).
+    Park,
+    /// Pedestrian footways and paths: villagers (w=60), wolves (w=40).
+    Footway,
+    /// Outdoor yards adjacent to detached / residential houses: cats (w=50), wolves (w=50).
+    ResidentialYard,
+}
+
+/// Place entities in outdoor areas using deterministic seeding.
+///
+/// Mirrors the seeding strategy of `place_building_entities` for cross-run reproducibility.
+pub fn place_outdoor_entities(
+    editor: &mut WorldEditor,
+    positions: &[(i32, i32)],
+    context: OutdoorContext,
+    seed: u64,
+) {
+    if positions.is_empty() {
+        return;
+    }
+
+    // Cumulative weight table: (entity_id, cumulative_weight) summing to 100
+    let entities: &[(&str, u64)] = match context {
+        OutdoorContext::Park => &[
+            ("minecraft:wolf", 40),
+            ("minecraft:cat", 70),       // 40+30
+            ("minecraft:villager", 100), // 40+30+30
+        ],
+        OutdoorContext::Footway => &[
+            ("minecraft:villager", 60),
+            ("minecraft:wolf", 100), // 60+40
+        ],
+        OutdoorContext::ResidentialYard => &[
+            ("minecraft:cat", 50),
+            ("minecraft:wolf", 100), // 50+50
+        ],
+    };
+
+    // How many entities to target for this area
+    let max_count: usize = match context {
+        OutdoorContext::Park => (positions.len() / 15).max(1),
+        OutdoorContext::Footway => (positions.len() / 8).max(1),
+        OutdoorContext::ResidentialYard => (seed.wrapping_mul(2654435761) % 3) as usize,
+    };
+
+    if max_count == 0 {
+        return;
+    }
+
+    let step = (positions.len() / (max_count + 1)).max(1);
+    for (i, &(x, z)) in positions.iter().enumerate() {
+        if i % step != step / 2 {
+            continue;
+        }
+        let entity_seed = seed.wrapping_mul(2654435761).wrapping_add(i as u64);
+        let roll = entity_seed % 100;
+        for &(entity_id, cum_weight) in entities {
+            if roll < cum_weight {
+                editor.add_entity(entity_id, x, 1, z, None);
+                break;
+            }
+        }
+    }
+}
+
 /// Maps a BuildingCategory to a theme context string.
 pub fn category_to_context(category: BuildingCategory) -> &'static str {
     match category {

--- a/src/ground_generation.rs
+++ b/src/ground_generation.rs
@@ -740,11 +740,18 @@ pub fn generate_ground_layer(
                                     land_cover::LC_TREE_COVER
                                         if slope <= 4 && ground_allows_trees =>
                                     {
-                                        let choice = rng.random_range(0..30);
+                                        // P2: 1-in-12 chance for a Colorado-appropriate tree
+                                        let choice = rng.random_range(0..12);
                                         if choice == 0 {
-                                            tree::Tree::create(
+                                            let tree_type = match rng.random_range(0..10) {
+                                                0..=5 => tree::TreeType::Spruce,
+                                                6..=8 => tree::TreeType::Oak,
+                                                _ => tree::TreeType::Birch,
+                                            };
+                                            tree::Tree::create_of_type(
                                                 editor,
                                                 (x, 1, z),
+                                                tree_type,
                                                 Some(building_footprints),
                                             );
                                         } else if ground_is_natural {
@@ -764,7 +771,7 @@ pub fn generate_ground_layer(
                                                     None,
                                                     None,
                                                 );
-                                            } else if choice <= 13 {
+                                            } else if choice <= 7 {
                                                 editor.set_block_absolute(
                                                     GRASS,
                                                     x,
@@ -777,8 +784,9 @@ pub fn generate_ground_layer(
                                         }
                                     }
                                     land_cover::LC_SHRUBLAND if ground_is_natural => {
+                                        // P2: 1-in-20 chance for a shrub (oak_leaves cluster)
                                         let choice = rng.random_range(0..100);
-                                        if choice < 2 {
+                                        if choice < 5 {
                                             editor.set_block_absolute(
                                                 OAK_LEAVES,
                                                 x,


### PR DESCRIPTION
Resolves [MIN-134](https://cirruslycloudy.com/MIN/issues/MIN-134)

## What was implemented

**P1 — Outdoor entity placement** (`entity_placement/mod.rs`, `buildings.rs`, `highways.rs`, `leisure.rs`)
- New `place_outdoor_entities()` function with `OutdoorContext` enum (Park, Footway, ResidentialYard)
- Parks/gardens/nature_reserves: wolves (w=40), cats (w=30), villagers (w=30) at ~1 per 15 cells
- Footways/paths: villagers (w=60), wolves (w=40) at ~1 per 8 bresenham blocks
- Residential yards (house/detached): cats + wolves, 0–2 per yard at perimeter nodes
- All seeding deterministic (same hash chain as `place_building_entities`)

**P2 — ESA land cover tree infill** (`ground_generation.rs`)
- `LC_TREE_COVER` tree density: 1/30 → 1/12; Colorado-appropriate variety (spruce 60%, oak 30%, birch 10%) via `Tree::create_of_type`
- `LC_SHRUBLAND` shrub density: 1/50 → 1/20 oak_leaves clusters

**P3 — Dog park wolf spawning** (`leisure.rs`)
- `leisure=dog_park` flood-fill interior: 1-in-6 per cell spawns `minecraft:wolf`

## Testing
- Regenerated map attached to MIN-134: `scarborough-neighborhood-MIN134-v2.zip` (1.1 MB)
- Same bbox as MIN-127: `38.944486,-104.736772,38.946126,-104.735133`