### PR TITLE
MIN-137: Fix pipeline job isolation and elevation baseline normalization

### DIFF
--- a/pipeline/src/generator/mod.rs
+++ b/pipeline/src/generator/mod.rs
@@ -117,7 +117,11 @@ impl Generator {
         spawn_lng: Option<f64>,
     ) -> Result<(), Box<dyn std::error::Error + Send + Sync>> {
         let mut command = Command::new(&self.arnis_binary);
+        // Each job runs in its own output directory so concurrent subprocesses
+        // never share a working directory or write relative-path temporaries
+        // to the same location (identical-worlds isolation, MIN-137).
         command
+            .current_dir(output_dir)
             .arg("--bbox")
             .arg(bbox)
             .arg("--output-dir")

--- a/pipeline/src/generator/mod.rs
+++ b/pipeline/src/generator/mod.rs
@@ -53,7 +53,12 @@ impl Generator {
             );
 
             match self
-                .invoke_generator(&bbox_str, &output_dir, location.spawn_lat, location.spawn_lng)
+                .invoke_generator(
+                    &bbox_str,
+                    &output_dir,
+                    location.spawn_lat,
+                    location.spawn_lng,
+                )
                 .await
             {
                 Ok(()) => {

--- a/src/elevation/postprocess.rs
+++ b/src/elevation/postprocess.rs
@@ -1164,24 +1164,29 @@ pub fn scale_to_minecraft(
     disable_height_limit: bool,
     extended_max_y: i32,
 ) -> Vec<Vec<f64>> {
-    // Derive min/max
-    let (min_height, max_height) = blurred_heights
-        .par_iter()
-        .map(|row| {
-            let mut lo = f64::MAX;
-            let mut hi = f64::MIN;
-            for &h in row {
-                if h.is_finite() {
-                    lo = lo.min(h);
-                    hi = hi.max(h);
-                }
-            }
-            (lo, hi)
-        })
-        .reduce(
-            || (f64::MAX, f64::MIN),
-            |(lo1, hi1), (lo2, hi2)| (lo1.min(lo2), hi1.max(hi2)),
-        );
+    // Collect finite heights; use Q1 (25th percentile) as the robust terrain
+    // minimum so sea-level artifact tiles (ocean/DEM-void cells returning 0 m)
+    // cannot anchor the entire terrain baseline at sea level.  Without this,
+    // a Denver bbox with even a small fraction of 0 m artifact cells would map
+    // real 1 600 m terrain to sky height (MIN-137).  Q1 is unaffected by
+    // contamination up to ~24 % of the grid; cells below Q1 clamp to
+    // ground_level in the final output.
+    let mut flat_finite: Vec<f64> = blurred_heights
+        .iter()
+        .flat_map(|row| row.iter().copied())
+        .filter(|h| h.is_finite())
+        .collect();
+
+    let max_height: f64 = flat_finite.iter().copied().fold(f64::MIN, f64::max);
+
+    let min_height: f64 = if flat_finite.len() >= 4 {
+        let q1_idx = flat_finite.len() / 4;
+        let (_, q1_val, _) =
+            flat_finite.select_nth_unstable_by(q1_idx, |a, b| a.partial_cmp(b).unwrap());
+        *q1_val
+    } else {
+        flat_finite.iter().copied().fold(f64::MAX, f64::min)
+    };
 
     let (min_height, _max_height, height_range) =
         if !min_height.is_finite() || !max_height.is_finite() || min_height >= max_height {
@@ -1473,6 +1478,38 @@ mod tests {
                     "MIN-129: Y-anchor out of [60, 70] at ground_level=64: {h}"
                 );
             }
+        }
+    }
+
+    /// MIN-137 regression guard: a grid of real inland terrain contaminated by
+    /// sea-level artifact tiles must still anchor near ground_level, not sky.
+    /// Simulates a Denver-like bbox where 10 % of DEM cells returned 0 m (ocean
+    /// or DEM-void encoding) while true terrain sits at 1 580–1 720 m.
+    #[test]
+    fn scale_to_minecraft_sea_level_artifacts_do_not_sky_anchor() {
+        // 10×10 grid: 10 cells at 0 m (artifact), 90 cells at 1 580–1 720 m
+        let mut rows: Vec<Vec<f64>> = Vec::new();
+        // Row 0: 10 artifact cells at 0 m
+        rows.push(vec![0.0; 10]);
+        // Rows 1–9: real Denver terrain (linear ramp 1 580–1 720 m)
+        for i in 1..10usize {
+            let row: Vec<f64> = (0..10)
+                .map(|j| 1580.0 + (i * 10 + j) as f64 * (140.0 / 89.0))
+                .collect();
+            rows.push(row);
+        }
+        let result = scale_to_minecraft(&rows, 1.0, 64, false, 319);
+        // Real terrain should map near ground_level, not to sky.
+        // Row 1 (lowest real terrain ~1 580 m) should be at or near y=64.
+        for &h in &result[1] {
+            assert!(
+                h <= 100.0,
+                "MIN-137: terrain anchored too high (sea-level artifact bled through): {h}"
+            );
+        }
+        // Highest terrain row should be above y=64 but within world bounds.
+        for &h in result.last().unwrap() {
+            assert!(h >= 64.0 && h <= 319.0, "Terrain out of world bounds: {h}");
         }
     }
 

--- a/src/elevation/postprocess.rs
+++ b/src/elevation/postprocess.rs
@@ -1509,7 +1509,10 @@ mod tests {
         }
         // Highest terrain row should be above y=64 but within world bounds.
         for &h in result.last().unwrap() {
-            assert!(h >= 64.0 && h <= 319.0, "Terrain out of world bounds: {h}");
+            assert!(
+                (64.0..=319.0).contains(&h),
+                "Terrain out of world bounds: {h}"
+            );
         }
     }
 


### PR DESCRIPTION
Resolves [MIN-137](https://cirruslycloudy.com/MIN/issues/MIN-137)

## Changes

### Fix 1 — Job state isolation (`pipeline/src/generator/mod.rs`)
Added `.current_dir(output_dir)` to each generator subprocess invocation. Without this, all concurrent subprocesses inherit the pipeline's working directory and any relative-path temporaries they write collide, producing identical output worlds.

### Fix 2 — Elevation baseline normalization (`src/elevation/postprocess.rs`)
Replaced the absolute minimum with **Q1 (25th percentile)** as the terrain baseline in `scale_to_minecraft`. Previously, a single ocean/DEM-void tile returning 0 m would set `min_height = 0`, mapping real inland terrain (e.g. Denver at 1 600 m) to sky height. Q1 is unaffected by artifact contamination up to ~24 % of the grid; cells below Q1 clamp to `ground_level` in the output.

New regression test: `scale_to_minecraft_sea_level_artifacts_do_not_sky_anchor` — simulates a Denver-like bbox with 10 % of cells at 0 m; verifies terrain anchors near y=64–100, not sky.

## Times Square test map results

```
SpawnY = 68  (target: near y=64)  ✓
SpawnX = 226, SpawnZ = 222  (within 336×389 map bounds)  ✓
Region file: 7.7 MB, 1024/1024 chunks occupied  ✓
Avg 6.9 KB/chunk (above 4,200 B empty-chunk floor)  ✓
Elevation range: 3.2 m → anchored at ground_level=64  ✓
All workspace tests pass  ✓
```