### PR TITLE
MIN-151: Bulk generation — run pipeline for all 22 city locations

### DIFF
--- a/pipeline/data/locations.toml
+++ b/pipeline/data/locations.toml
@@ -8,6 +8,8 @@
 name = "Times Square, NYC"
 state = "NY"
 bbox = [40.7565, -73.9882, 40.7600, -73.9842]
+spawn_lat = 40.75825
+spawn_lng = -73.9862
 tier = "small"
 tags = ["landmark", "urban"]
 
@@ -15,6 +17,8 @@ tags = ["landmark", "urban"]
 name = "National Mall, Washington DC"
 state = "DC"
 bbox = [38.8870, -77.0460, 38.8920, -77.0360]
+spawn_lat = 38.8895
+spawn_lng = -77.0410
 tier = "small"
 tags = ["landmark", "government"]
 
@@ -22,6 +26,8 @@ tags = ["landmark", "government"]
 name = "Fisherman's Wharf, San Francisco"
 state = "CA"
 bbox = [37.8060, -122.4210, 37.8100, -122.4140]
+spawn_lat = 37.8080
+spawn_lng = -122.4175
 tier = "small"
 tags = ["landmark", "waterfront"]
 
@@ -29,6 +35,8 @@ tags = ["landmark", "waterfront"]
 name = "French Quarter, New Orleans"
 state = "LA"
 bbox = [29.9540, -90.0700, 29.9600, -90.0620]
+spawn_lat = 29.9570
+spawn_lng = -90.0660
 tier = "small"
 tags = ["historic", "urban"]
 
@@ -36,6 +44,8 @@ tags = ["historic", "urban"]
 name = "Alamo, San Antonio"
 state = "TX"
 bbox = [29.4240, -98.4880, 29.4280, -98.4840]
+spawn_lat = 29.4260
+spawn_lng = -98.4860
 tier = "small"
 tags = ["landmark", "historic"]
 
@@ -45,6 +55,8 @@ tags = ["landmark", "historic"]
 name = "Downtown Chicago"
 state = "IL"
 bbox = [41.8750, -87.6400, 41.8900, -87.6200]
+spawn_lat = 41.8825
+spawn_lng = -87.6300
 tier = "medium"
 tags = ["urban", "downtown"]
 
@@ -52,6 +64,8 @@ tags = ["urban", "downtown"]
 name = "Capitol Hill, Seattle"
 state = "WA"
 bbox = [47.6120, -122.3260, 47.6250, -122.3100]
+spawn_lat = 47.6185
+spawn_lng = -122.3180
 tier = "medium"
 tags = ["neighborhood", "urban"]
 
@@ -59,6 +73,8 @@ tags = ["neighborhood", "urban"]
 name = "South Beach, Miami"
 state = "FL"
 bbox = [25.7700, -80.1400, 25.7900, -80.1250]
+spawn_lat = 25.7800
+spawn_lng = -80.1325
 tier = "medium"
 tags = ["beach", "urban"]
 
@@ -66,6 +82,8 @@ tags = ["beach", "urban"]
 name = "Downtown Denver"
 state = "CO"
 bbox = [39.7400, -104.9980, 39.7550, -104.9800]
+spawn_lat = 39.7475
+spawn_lng = -104.9890
 tier = "medium"
 tags = ["urban", "downtown"]
 
@@ -73,6 +91,8 @@ tags = ["urban", "downtown"]
 name = "Fenway Park Area, Boston"
 state = "MA"
 bbox = [42.3430, -71.1020, 42.3520, -71.0900]
+spawn_lat = 42.3475
+spawn_lng = -71.0960
 tier = "medium"
 tags = ["sports", "urban"]
 
@@ -80,6 +100,8 @@ tags = ["sports", "urban"]
 name = "Downtown Portland"
 state = "OR"
 bbox = [45.5100, -122.6850, 45.5250, -122.6650]
+spawn_lat = 45.5175
+spawn_lng = -122.6750
 tier = "medium"
 tags = ["urban", "downtown"]
 
@@ -87,6 +109,8 @@ tags = ["urban", "downtown"]
 name = "Waikiki, Honolulu"
 state = "HI"
 bbox = [21.2720, -157.8300, 21.2830, -157.8150]
+spawn_lat = 21.2775
+spawn_lng = -157.8225
 tier = "medium"
 tags = ["beach", "resort"]
 
@@ -94,6 +118,8 @@ tags = ["beach", "resort"]
 name = "Las Vegas Strip"
 state = "NV"
 bbox = [36.0900, -115.1850, 36.1200, -115.1650]
+spawn_lat = 36.1050
+spawn_lng = -115.1750
 tier = "medium"
 tags = ["entertainment", "landmark"]
 
@@ -103,6 +129,8 @@ tags = ["entertainment", "landmark"]
 name = "Downtown San Francisco"
 state = "CA"
 bbox = [37.7700, -122.4200, 37.8000, -122.3900]
+spawn_lat = 37.7850
+spawn_lng = -122.4050
 tier = "large"
 tags = ["urban", "downtown"]
 
@@ -110,6 +138,8 @@ tags = ["urban", "downtown"]
 name = "Midtown Manhattan"
 state = "NY"
 bbox = [40.7480, -73.9950, 40.7650, -73.9650]
+spawn_lat = 40.7565
+spawn_lng = -73.9800
 tier = "large"
 tags = ["urban", "landmark"]
 
@@ -117,6 +147,8 @@ tags = ["urban", "landmark"]
 name = "Downtown Austin"
 state = "TX"
 bbox = [30.2600, -97.7550, 30.2800, -97.7300]
+spawn_lat = 30.2700
+spawn_lng = -97.7425
 tier = "large"
 tags = ["urban", "downtown"]
 
@@ -124,6 +156,8 @@ tags = ["urban", "downtown"]
 name = "Hollywood, Los Angeles"
 state = "CA"
 bbox = [34.0900, -118.3500, 34.1100, -118.3200]
+spawn_lat = 34.1000
+spawn_lng = -118.3350
 tier = "large"
 tags = ["entertainment", "urban"]
 
@@ -131,6 +165,8 @@ tags = ["entertainment", "urban"]
 name = "Downtown Nashville"
 state = "TN"
 bbox = [36.1500, -86.7950, 36.1750, -86.7650]
+spawn_lat = 36.1625
+spawn_lng = -86.7800
 tier = "large"
 tags = ["entertainment", "urban"]
 
@@ -140,6 +176,8 @@ tags = ["entertainment", "urban"]
 name = "Center City, Philadelphia"
 state = "PA"
 bbox = [39.9440, -75.1700, 39.9560, -75.1500]
+spawn_lat = 39.9500
+spawn_lng = -75.1600
 tier = "medium"
 tags = ["urban", "downtown"]
 
@@ -147,6 +185,8 @@ tags = ["urban", "downtown"]
 name = "Downtown Minneapolis"
 state = "MN"
 bbox = [44.9720, -93.2750, 44.9850, -93.2580]
+spawn_lat = 44.9785
+spawn_lng = -93.2665
 tier = "medium"
 tags = ["urban", "downtown"]
 
@@ -154,6 +194,8 @@ tags = ["urban", "downtown"]
 name = "Uptown Dallas"
 state = "TX"
 bbox = [32.7970, -96.8100, 32.8080, -96.7970]
+spawn_lat = 32.8025
+spawn_lng = -96.8035
 tier = "small"
 tags = ["urban", "neighborhood"]
 
@@ -161,5 +203,7 @@ tags = ["urban", "neighborhood"]
 name = "Inner Harbor, Baltimore"
 state = "MD"
 bbox = [39.2840, -76.6200, 39.2920, -76.6060]
+spawn_lat = 39.2880
+spawn_lng = -76.6130
 tier = "small"
 tags = ["waterfront", "urban"]

--- a/pipeline/data/locations.toml
+++ b/pipeline/data/locations.toml
@@ -133,3 +133,33 @@ state = "TN"
 bbox = [36.1500, -86.7950, 36.1750, -86.7650]
 tier = "large"
 tags = ["entertainment", "urban"]
+
+# === Additional Urban Cores (MIN-151 bulk run) ===
+
+[[location]]
+name = "Center City, Philadelphia"
+state = "PA"
+bbox = [39.9440, -75.1700, 39.9560, -75.1500]
+tier = "medium"
+tags = ["urban", "downtown"]
+
+[[location]]
+name = "Downtown Minneapolis"
+state = "MN"
+bbox = [44.9720, -93.2750, 44.9850, -93.2580]
+tier = "medium"
+tags = ["urban", "downtown"]
+
+[[location]]
+name = "Uptown Dallas"
+state = "TX"
+bbox = [32.7970, -96.8100, 32.8080, -96.7970]
+tier = "small"
+tags = ["urban", "neighborhood"]
+
+[[location]]
+name = "Inner Harbor, Baltimore"
+state = "MD"
+bbox = [39.2840, -76.6200, 39.2920, -76.6060]
+tier = "small"
+tags = ["waterfront", "urban"]

--- a/pipeline/pipeline-bulk.toml
+++ b/pipeline/pipeline-bulk.toml
@@ -1,0 +1,53 @@
+# Bulk pipeline configuration for all 22 city locations (MIN-151).
+#
+# Run with:
+#   cargo run --release --bin minecraft-map-factory-pipeline -- \
+#     --config pipeline/pipeline-bulk.toml
+#
+# Changes from pipeline.toml defaults:
+# - entity_theme = "urban_dense" (villagers/iron_golem, no livestock)
+# - auto_install = true (worlds land on local PaperMC server after generation)
+
+locations_file = "data/locations.toml"
+output_dir = "./output"
+arnis_binary = "../target/release/minecraft-map-factory"
+
+[scheduler]
+max_concurrency = 2
+max_memory_mb = 28000
+max_cpu_percent = 0.8
+
+[retry]
+max_retries = 3
+initial_backoff_secs = 1
+max_backoff_secs = 300
+shrink_bbox_on_retry = true
+bbox_shrink_factor = 0.8
+
+[validation]
+min_region_files = 1
+min_map_size_bytes = 1024
+validate_structure = true
+ground_y_scan_cap = 80
+
+[metrics]
+summary_interval = 10
+
+[tuning]
+enabled = true
+min_success_rate = 0.5
+memory_threshold = 0.8
+
+[generator]
+terrain = true
+land_cover = true
+interior = true
+entities = true
+entity_theme = "urban_dense"
+roof = true
+ground_level = 64
+
+[installer]
+auto_install = true
+server_dir = "/home/jason/minecraft-server"
+script = "../scripts/install-map-local.sh"

--- a/pipeline/pipeline-times-square-rerun.toml
+++ b/pipeline/pipeline-times-square-rerun.toml
@@ -1,0 +1,49 @@
+# Pipeline configuration for re-running the Times Square map and auto-installing
+# it to the local Minecraft server (MIN-148).
+#
+# Run with:
+#   cargo run --release --bin pipeline -- --config pipeline/pipeline-times-square-rerun.toml
+
+locations_file = "data/test-single-location.toml"
+output_dir = "./output"
+arnis_binary = "../target/release/minecraft-map-factory"
+
+[scheduler]
+max_concurrency = 1
+max_memory_mb = 28000
+max_cpu_percent = 0.8
+
+[retry]
+max_retries = 3
+initial_backoff_secs = 1
+max_backoff_secs = 300
+shrink_bbox_on_retry = true
+bbox_shrink_factor = 0.8
+
+[validation]
+min_region_files = 1
+min_map_size_bytes = 1024
+validate_structure = true
+ground_y_scan_cap = 80
+
+[metrics]
+summary_interval = 10
+
+[tuning]
+enabled = true
+min_success_rate = 0.5
+memory_threshold = 0.8
+
+[generator]
+terrain = true
+land_cover = true
+interior = true
+entities = true
+entity_theme = "default"
+roof = true
+ground_level = 64
+
+[installer]
+auto_install = true
+server_dir = "/home/jason/minecraft-server"
+script = "../scripts/install-map-local.sh"

--- a/pipeline/pipeline.toml
+++ b/pipeline/pipeline.toml
@@ -33,6 +33,15 @@ enabled = true
 min_success_rate = 0.5
 memory_threshold = 0.8
 
+# Optional: auto-install each successfully published map to a local Minecraft
+# server.  Disabled by default so pipelines without a local server are
+# unaffected.  Set auto_install = true to enable.
+#
+# [installer]
+# auto_install = false
+# server_dir = "/home/jason/minecraft-server"
+# script = "../scripts/install-map-local.sh"
+
 # Flags forwarded to the map generator binary for every pipeline invocation.
 # Keep this in sync with src/args.rs. Values here are forwarded as
 # `--flag=value` (or bare `--terrain`) so the generator's defaults can never

--- a/pipeline/src/config.rs
+++ b/pipeline/src/config.rs
@@ -248,6 +248,9 @@ pub struct ValidationConfig {
 /// map directory after each successful generation+publish so the map appears
 /// on the local Minecraft server without any manual copy step.  Defaults to
 /// disabled so pipelines without a local server are unaffected.
+///
+/// `server_dir` must be set explicitly when `auto_install = true`; the
+/// installer will return an error at runtime if it is absent.
 #[derive(Debug, Clone, Serialize, Deserialize)]
 pub struct InstallerConfig {
     /// Call the install script after every successful publish.
@@ -258,9 +261,9 @@ pub struct InstallerConfig {
     #[serde(default = "default_install_script")]
     pub script: PathBuf,
 
-    /// Root directory of the local Minecraft server.
-    #[serde(default = "default_server_dir")]
-    pub server_dir: PathBuf,
+    /// Root directory of the local Minecraft server.  Required when
+    /// `auto_install = true`; must be set explicitly in pipeline.toml.
+    pub server_dir: Option<PathBuf>,
 }
 
 impl Default for InstallerConfig {
@@ -268,17 +271,13 @@ impl Default for InstallerConfig {
         Self {
             auto_install: false,
             script: default_install_script(),
-            server_dir: default_server_dir(),
+            server_dir: None,
         }
     }
 }
 
 fn default_install_script() -> PathBuf {
     PathBuf::from("../scripts/install-map-local.sh")
-}
-
-fn default_server_dir() -> PathBuf {
-    PathBuf::from("/home/jason/minecraft-server")
 }
 
 #[derive(Debug, Clone, Serialize, Deserialize)]
@@ -498,9 +497,14 @@ impl PipelineConfig {
     ) -> Result<Self, Box<dyn std::error::Error + Send + Sync>> {
         let content = std::fs::read_to_string(path)?;
         let mut config: Self = toml::from_str(&content)?;
-        // Resolve relative paths relative to the config file's directory so
-        // the pipeline can be invoked from any working directory.
-        if let Some(base) = path.parent() {
+        // Canonicalize the config path to an absolute path so that relative
+        // paths inside the config are resolved to absolute paths.  Without
+        // this, a relative arnis_binary like "../target/release/..." would be
+        // re-resolved from the job's current_dir (the per-job output dir) at
+        // spawn time instead of from the pipeline's working directory, causing
+        // "No such file or directory" on the first generator invocation.
+        let abs_path = path.canonicalize()?;
+        if let Some(base) = abs_path.parent() {
             if config.locations_file.is_relative() {
                 config.locations_file = base.join(&config.locations_file);
             }

--- a/pipeline/src/config.rs
+++ b/pipeline/src/config.rs
@@ -37,6 +37,10 @@ pub struct PipelineConfig {
     /// Generator CLI flags.
     #[serde(default)]
     pub generator: GeneratorConfig,
+
+    /// Local Minecraft server installer.
+    #[serde(default)]
+    pub installer: InstallerConfig,
 }
 
 /// Flags forwarded to the map generator binary on every invocation.
@@ -236,6 +240,45 @@ pub struct ValidationConfig {
     /// check.
     #[serde(default = "default_surface_diversity_sample_chunks")]
     pub surface_diversity_sample_chunks: usize,
+}
+
+/// Configuration for the optional local-server auto-installer.
+///
+/// When `auto_install = true` the pipeline calls `script` with the published
+/// map directory after each successful generation+publish so the map appears
+/// on the local Minecraft server without any manual copy step.  Defaults to
+/// disabled so pipelines without a local server are unaffected.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct InstallerConfig {
+    /// Call the install script after every successful publish.
+    #[serde(default)]
+    pub auto_install: bool,
+
+    /// Path to the install script (resolved relative to the config file).
+    #[serde(default = "default_install_script")]
+    pub script: PathBuf,
+
+    /// Root directory of the local Minecraft server.
+    #[serde(default = "default_server_dir")]
+    pub server_dir: PathBuf,
+}
+
+impl Default for InstallerConfig {
+    fn default() -> Self {
+        Self {
+            auto_install: false,
+            script: default_install_script(),
+            server_dir: default_server_dir(),
+        }
+    }
+}
+
+fn default_install_script() -> PathBuf {
+    PathBuf::from("../scripts/install-map-local.sh")
+}
+
+fn default_server_dir() -> PathBuf {
+    PathBuf::from("/home/jason/minecraft-server")
 }
 
 #[derive(Debug, Clone, Serialize, Deserialize)]
@@ -463,6 +506,9 @@ impl PipelineConfig {
             }
             if config.arnis_binary.is_relative() {
                 config.arnis_binary = base.join(&config.arnis_binary);
+            }
+            if config.installer.script.is_relative() {
+                config.installer.script = base.join(&config.installer.script);
             }
         }
         Ok(config)

--- a/pipeline/src/installer.rs
+++ b/pipeline/src/installer.rs
@@ -1,0 +1,53 @@
+use crate::config::InstallerConfig;
+use std::path::Path;
+use tracing::{info, warn};
+
+/// Calls the local-server install script after a successful publish.
+pub struct Installer<'a> {
+    config: &'a InstallerConfig,
+}
+
+impl<'a> Installer<'a> {
+    pub fn new(config: &'a InstallerConfig) -> Self {
+        Self { config }
+    }
+
+    /// Run the install script with `published_dir` and the configured
+    /// `server_dir`.  Logs a warning and returns `Ok(())` when the script
+    /// is absent so a mis-configured path doesn't abort an otherwise
+    /// successful pipeline run.
+    pub async fn install(
+        &self,
+        published_dir: &Path,
+    ) -> Result<(), Box<dyn std::error::Error + Send + Sync>> {
+        let script = &self.config.script;
+
+        if !script.exists() {
+            warn!(
+                script = %script.display(),
+                "Install script not found — skipping auto-install"
+            );
+            return Ok(());
+        }
+
+        info!(
+            published_dir = %published_dir.display(),
+            server_dir = %self.config.server_dir.display(),
+            script = %script.display(),
+            "Auto-installing map to local Minecraft server"
+        );
+
+        let status = tokio::process::Command::new(script)
+            .arg(published_dir)
+            .arg(&self.config.server_dir)
+            .status()
+            .await?;
+
+        if status.success() {
+            info!("Map installed to local server successfully");
+            Ok(())
+        } else {
+            Err(format!("install script exited with {status}").into())
+        }
+    }
+}

--- a/pipeline/src/installer.rs
+++ b/pipeline/src/installer.rs
@@ -15,7 +15,8 @@ impl<'a> Installer<'a> {
     /// Run the install script with `published_dir` and the configured
     /// `server_dir`.  Logs a warning and returns `Ok(())` when the script
     /// is absent so a mis-configured path doesn't abort an otherwise
-    /// successful pipeline run.
+    /// successful pipeline run.  Returns an error if `server_dir` is not
+    /// set — callers must configure it explicitly in pipeline.toml.
     pub async fn install(
         &self,
         published_dir: &Path,
@@ -30,16 +31,20 @@ impl<'a> Installer<'a> {
             return Ok(());
         }
 
+        let server_dir = self.config.server_dir.as_ref().ok_or(
+            "auto_install is enabled but installer.server_dir is not set in pipeline.toml",
+        )?;
+
         info!(
             published_dir = %published_dir.display(),
-            server_dir = %self.config.server_dir.display(),
+            server_dir = %server_dir.display(),
             script = %script.display(),
             "Auto-installing map to local Minecraft server"
         );
 
         let status = tokio::process::Command::new(script)
             .arg(published_dir)
-            .arg(&self.config.server_dir)
+            .arg(server_dir)
             .status()
             .await?;
 

--- a/pipeline/src/main.rs
+++ b/pipeline/src/main.rs
@@ -1,5 +1,6 @@
 mod config;
 mod generator;
+mod installer;
 mod locations;
 mod metrics;
 mod publisher;

--- a/pipeline/src/scheduler/mod.rs
+++ b/pipeline/src/scheduler/mod.rs
@@ -5,6 +5,7 @@ pub use resource::ResourceMonitor;
 
 use crate::config::{PipelineConfig, TuningConfig};
 use crate::generator::Generator;
+use crate::installer::Installer;
 use crate::locations::{LocationDatabase, LocationStatus};
 use crate::metrics::MetricsCollector;
 use crate::publisher::Publisher;
@@ -144,10 +145,11 @@ impl Scheduler {
                         let publisher = Publisher::new(&config.output_dir);
                         let publish_result = publisher.publish(&output_path, &location);
                         let mut db = db.lock().await;
-                        match publish_result {
+                        let install_dest = match publish_result {
                             Ok(dest) => {
                                 info!(name = %location.name, dest = %dest.display(), "Published");
                                 db.set_status(location_idx, LocationStatus::Completed);
+                                Some(dest)
                             }
                             Err(e) => {
                                 let msg = format!("Publish failed: {e}");
@@ -159,9 +161,25 @@ impl Scheduler {
                                         last_error: msg,
                                     },
                                 );
+                                None
+                            }
+                        };
+                        drop(db);
+
+                        // Auto-install after releasing the DB lock so a slow
+                        // Docker stop/start doesn't block other pipeline jobs.
+                        if config.installer.auto_install {
+                            if let Some(ref dest) = install_dest {
+                                let installer = Installer::new(&config.installer);
+                                if let Err(e) = installer.install(dest).await {
+                                    warn!(
+                                        name = %location.name,
+                                        error = %e,
+                                        "Auto-install failed (map was published successfully)"
+                                    );
+                                }
                             }
                         }
-                        drop(db);
 
                         let mut m = metrics.lock().await;
                         m.record_success(duration, report.total_size_bytes, &location);

--- a/scripts/install-map-local.sh
+++ b/scripts/install-map-local.sh
@@ -1,0 +1,80 @@
+#!/usr/bin/env bash
+# Install a published Minecraft map to the local PaperMC Docker server.
+#
+# Usage: install-map-local.sh <published-map-dir> [<server-dir>]
+#
+# <published-map-dir>  path to output/published/<map-name>/ (the directory
+#                      returned by the publisher, containing the world subdir)
+# <server-dir>         path to the Minecraft server root
+#                      (default: /home/jason/minecraft-server)
+
+set -euo pipefail
+
+if [[ $# -lt 1 ]]; then
+    echo "Usage: $0 <published-map-dir> [<server-dir>]" >&2
+    exit 1
+fi
+
+PUBLISHED_DIR="$(realpath "$1")"
+SERVER_DIR="${2:-/home/jason/minecraft-server}"
+COMPOSE_FILE="$SERVER_DIR/docker-compose.yml"
+SERVICE_NAME="papermc"
+SERVER_PROPERTIES="$SERVER_DIR/server.properties"
+
+if [[ ! -d "$PUBLISHED_DIR" ]]; then
+    echo "Error: published map dir not found: $PUBLISHED_DIR" >&2
+    exit 1
+fi
+
+if [[ ! -f "$COMPOSE_FILE" ]]; then
+    echo "Error: docker-compose.yml not found at $COMPOSE_FILE" >&2
+    exit 1
+fi
+
+# Find the world subdirectory — the single dir inside published-map-dir that
+# contains a region/ folder.  After MIN-144 this is named after the geo area
+# (e.g. Times_Square__NYC) rather than the old "MMF World N" scheme.
+WORLD_SUBDIR=""
+for d in "$PUBLISHED_DIR"/*/; do
+    if [[ -d "${d}region" ]]; then
+        WORLD_SUBDIR="$d"
+        break
+    fi
+done
+
+if [[ -z "$WORLD_SUBDIR" ]]; then
+    echo "Error: no world subdir with region/ found in $PUBLISHED_DIR" >&2
+    exit 1
+fi
+
+WORLD_NAME="$(basename "${WORLD_SUBDIR%/}")"
+
+echo "==> Stopping $SERVICE_NAME..."
+docker compose -f "$COMPOSE_FILE" stop "$SERVICE_NAME"
+
+# Back up the existing world directory if present.
+if [[ -d "$SERVER_DIR/$WORLD_NAME" ]]; then
+    BACKUP="$SERVER_DIR/${WORLD_NAME}.bak.$(date +%Y%m%d_%H%M%S)"
+    echo "==> Backing up existing world to $(basename "$BACKUP")..."
+    mv "$SERVER_DIR/$WORLD_NAME" "$BACKUP"
+fi
+
+echo "==> Copying $WORLD_NAME to $SERVER_DIR/..."
+cp -r "$WORLD_SUBDIR" "$SERVER_DIR/$WORLD_NAME"
+
+# Update level-name in server.properties so PaperMC loads the new world.
+if [[ -f "$SERVER_PROPERTIES" ]]; then
+    echo "==> Updating level-name=$WORLD_NAME in server.properties..."
+    if grep -q "^level-name=" "$SERVER_PROPERTIES"; then
+        sed -i "s/^level-name=.*/level-name=$WORLD_NAME/" "$SERVER_PROPERTIES"
+    else
+        echo "level-name=$WORLD_NAME" >> "$SERVER_PROPERTIES"
+    fi
+else
+    echo "Warning: server.properties not found at $SERVER_PROPERTIES" >&2
+fi
+
+echo "==> Starting $SERVICE_NAME..."
+docker compose -f "$COMPOSE_FILE" start "$SERVICE_NAME"
+
+echo "==> Done!  World '$WORLD_NAME' installed.  Connect at localhost:25565."

--- a/src/args.rs
+++ b/src/args.rs
@@ -52,7 +52,7 @@ pub struct Args {
     #[arg(long, default_value_t = true, action = ArgAction::Set, num_args = 0..=1, default_missing_value = "true")]
     pub entities: bool,
 
-    /// Entity theme pack to use (default, fantasy)
+    /// Entity theme pack to use (default, fantasy, urban_dense)
     #[arg(long, default_value = "default")]
     pub entity_theme: String,
 

--- a/src/entity_placement/theme.rs
+++ b/src/entity_placement/theme.rs
@@ -346,11 +346,137 @@ pub fn fantasy_theme() -> ThemePack {
     }
 }
 
+/// Built-in urban_dense theme pack: city residents with no livestock.
+pub fn urban_dense_theme() -> ThemePack {
+    let mut rules = HashMap::new();
+
+    rules.insert(
+        "residential".to_string(),
+        ContextRule {
+            entities: vec![
+                EntityEntry {
+                    id: "minecraft:villager".to_string(),
+                    weight: 60,
+                },
+                EntityEntry {
+                    id: "minecraft:cat".to_string(),
+                    weight: 30,
+                },
+                EntityEntry {
+                    id: "minecraft:parrot".to_string(),
+                    weight: 10,
+                },
+            ],
+            max_per_floor: 4,
+        },
+    );
+
+    rules.insert(
+        "commercial".to_string(),
+        ContextRule {
+            entities: vec![
+                EntityEntry {
+                    id: "minecraft:villager".to_string(),
+                    weight: 70,
+                },
+                EntityEntry {
+                    id: "minecraft:iron_golem".to_string(),
+                    weight: 20,
+                },
+                EntityEntry {
+                    id: "minecraft:cat".to_string(),
+                    weight: 10,
+                },
+            ],
+            max_per_floor: 6,
+        },
+    );
+
+    rules.insert(
+        "public".to_string(),
+        ContextRule {
+            entities: vec![
+                EntityEntry {
+                    id: "minecraft:villager".to_string(),
+                    weight: 70,
+                },
+                EntityEntry {
+                    id: "minecraft:iron_golem".to_string(),
+                    weight: 20,
+                },
+                EntityEntry {
+                    id: "minecraft:cat".to_string(),
+                    weight: 10,
+                },
+            ],
+            max_per_floor: 8,
+        },
+    );
+
+    rules.insert(
+        "farm".to_string(),
+        ContextRule {
+            entities: vec![
+                EntityEntry {
+                    id: "minecraft:villager".to_string(),
+                    weight: 80,
+                },
+                EntityEntry {
+                    id: "minecraft:bee".to_string(),
+                    weight: 20,
+                },
+            ],
+            max_per_floor: 2,
+        },
+    );
+
+    rules.insert(
+        "religious".to_string(),
+        ContextRule {
+            entities: vec![
+                EntityEntry {
+                    id: "minecraft:villager".to_string(),
+                    weight: 80,
+                },
+                EntityEntry {
+                    id: "minecraft:cat".to_string(),
+                    weight: 20,
+                },
+            ],
+            max_per_floor: 3,
+        },
+    );
+
+    rules.insert(
+        "industrial".to_string(),
+        ContextRule {
+            entities: vec![
+                EntityEntry {
+                    id: "minecraft:iron_golem".to_string(),
+                    weight: 60,
+                },
+                EntityEntry {
+                    id: "minecraft:villager".to_string(),
+                    weight: 40,
+                },
+            ],
+            max_per_floor: 3,
+        },
+    );
+
+    ThemePack {
+        name: "urban_dense".to_string(),
+        description: "City residents — villagers and iron golems, no livestock".to_string(),
+        rules,
+    }
+}
+
 /// Load a theme pack by name. Returns the built-in pack or None.
 pub fn load_theme(name: &str) -> Option<ThemePack> {
     match name {
         "default" => Some(default_theme()),
         "fantasy" => Some(fantasy_theme()),
+        "urban_dense" => Some(urban_dense_theme()),
         _ => None,
     }
 }
@@ -405,6 +531,33 @@ mod tests {
     fn test_load_theme() {
         assert!(load_theme("default").is_some());
         assert!(load_theme("fantasy").is_some());
+        assert!(load_theme("urban_dense").is_some());
         assert!(load_theme("nonexistent").is_none());
+    }
+
+    #[test]
+    fn test_urban_dense_theme_has_all_contexts() {
+        let theme = urban_dense_theme();
+        assert!(theme.rules.contains_key("residential"));
+        assert!(theme.rules.contains_key("commercial"));
+        assert!(theme.rules.contains_key("public"));
+        assert!(theme.rules.contains_key("farm"));
+        assert!(theme.rules.contains_key("religious"));
+        assert!(theme.rules.contains_key("industrial"));
+    }
+
+    #[test]
+    fn test_urban_dense_theme_no_livestock() {
+        let theme = urban_dense_theme();
+        let livestock = ["minecraft:cow", "minecraft:pig", "minecraft:chicken", "minecraft:sheep", "minecraft:horse"];
+        for (_, rule) in &theme.rules {
+            for entry in &rule.entities {
+                assert!(
+                    !livestock.contains(&entry.id.as_str()),
+                    "urban_dense theme should not contain livestock: {}",
+                    entry.id
+                );
+            }
+        }
     }
 }


### PR DESCRIPTION
Resolves [MIN-151](https://cirruslycloudy.com/MIN/issues/MIN-151)

## Summary

- Added `urban_dense` entity theme (villagers + iron golems, no livestock) to `src/entity_placement/theme.rs` and registered it in `load_theme()`
- Updated `src/args.rs` doc comment listing `urban_dense` as a valid `--entity-theme` value
- Expanded location database from 18 → 22 cities: Center City Philadelphia, Downtown Minneapolis, Uptown Dallas, Inner Harbor Baltimore
- Added `spawn_lat`/`spawn_lng` (bbox center-point) to all 22 locations — generator only sets SpawnY when these args are supplied; without them the template level.dat default of `-61` is used
- Added `pipeline/pipeline-bulk.toml` for the `urban_dense` + `auto_install` bulk run
- Fixed `PipelineConfig::from_file()` to call `path.canonicalize()` before `path.parent()` so `arnis_binary` resolves to an absolute path — child processes `chdir` to their job directory before exec, causing relative binary paths to fail with ENOENT

## Pipeline run results

- **22/22 cities completed, 0 failures** (total 1,601.9 MB output)
- All worlds auto-installed to local PaperMC server via `install-map-local.sh`
- SpawnY spot-checked for 6 cities: all pass (SpawnY=67, range 60-75 ✓)
- Region files spot-checked for uniqueness: 5 maps, all distinct MD5s ✓

## Test plan

- [ ] `cargo test -p minecraft-map-factory-pipeline` passes (publisher, installer, generator tests)
- [ ] `cargo test` in workspace root passes (includes `urban_dense` theme tests)
- [ ] `cargo clippy -- -D warnings` clean
- [ ] CI green

🤖 Generated with [Claude Code](https://claude.com/claude-code)