### PR TITLE
MIN-165: auto-deploy + live container HEAD verification scripts

### DIFF
--- a/docs/smoke-testing.md
+++ b/docs/smoke-testing.md
@@ -1,0 +1,119 @@
+# Live-Server Smoke Check Runbook
+
+End-to-end smoke testing for Minecraft datapacks against the live PaperMC
+container at `hp-mini-pc` (192.168.7.211). Background: [MIN-156](/MIN/issues/MIN-156).
+
+## When to run
+
+Run a smoke check whenever a change touches any of the following:
+
+- `pack_format` or `pack.mcmeta` — wrong values are silently accepted at
+  load time but cause runtime failures or are rejected outright
+- Function paths (`data/<namespace>/function/`) — the directory name is
+  singular `function`, not `functions`; the server will silently skip
+  misnamed directories
+- Command syntax inside `.mcfunction` files — server version dictates valid
+  commands; syntax errors are only caught at execution time
+- `load.json` / `tick.json` tag function lists
+
+A smoke check is not needed for changes that only touch map geometry (`.mca`
+region files), textures, or non-datapack pipeline code.
+
+## How to run
+
+```bash
+scripts/motfb-smoke.sh <path-to-built-pack> [function-to-exercise ...]
+```
+
+`<path-to-built-pack>` is the local directory or `.zip` of the datapack to
+test. Optionally pass one or more fully-qualified Minecraft function IDs
+(e.g. `motfb:init`) to exercise after the pack loads.
+
+### Example
+
+```bash
+# Test a freshly-built MOTFB datapack and run its init function
+scripts/motfb-smoke.sh output/motfb-datapack motfb:init
+
+# Quick pack_format / load check only (no extra functions)
+scripts/motfb-smoke.sh output/motfb-datapack
+```
+
+The script handles all server-side steps:
+
+1. Copies the pack into the container's datapacks directory
+2. Fixes file ownership
+3. Issues `reload` + `datapack enable`
+4. Reads `datapack list` and tails `latest.log`
+5. Runs any extra functions you specified via rcon
+6. **Cleans up**: removes the pack and reloads again
+
+## What to check in the output
+
+A passing run looks like:
+
+```
+[motfb-smoke] pack_format accepted: <N>
+[motfb-smoke] datapack list: "file/motfb-test-NNN" (enabled)
+[motfb-smoke] WARN/ERROR count: 0
+[motfb-smoke] function motfb:init → <output or "no output">
+[motfb-smoke] PASS — cleanup done
+```
+
+Flag any run that contains:
+
+| Signal | Meaning |
+|--------|---------|
+| `pack_format` rejected or `Unknown pack_format` in log | Wrong format version; check MC 26.x pack_format value |
+| `WARN` or `ERROR` in log grep | Bad command syntax, missing function file, tag resolution failure |
+| `datapack list` does not show the test pack as `(enabled)` | Load failure; inspect full log around `[DataPackManager]` |
+| Script exits non-zero | Infrastructure problem — check docker socket / RCON connectivity |
+
+## Guardrails
+
+The script enforces these limits automatically — you cannot override them
+at the call site:
+
+- **Temp name only**: packs are installed under an ephemeral name
+  (`motfb-test-<random>`), never under the production pack name.
+- **No production world mutations**: the script never touches
+  `Times_Square__NYC` map data or any other world files.
+- **Auto-cleanup**: the temp pack is removed and the server is reloaded
+  whether the smoke check passes or fails. A crash in the script still
+  triggers the cleanup trap.
+- **No destructive commands**: the script never issues `/op`, `/stop`,
+  `/save-off`, or any command that modifies world state beyond loading a
+  datapack.
+
+## Server details (for reference)
+
+| Item | Value |
+|------|-------|
+| Host | `hp-mini-pc` — 192.168.7.211 |
+| Container | `minecraft-papermc` (`itzg/minecraft-server`) |
+| MC version | 26.1.2 (Paper build 60) |
+| RCON | `docker exec minecraft-papermc rcon-cli "<cmd>"` |
+| Datapacks dir | `/data/Times_Square__NYC/datapacks/` |
+| Host volume | `/home/jason/minecraft-server/data/` ↔ `/data/` |
+| `function-permission-level` | 2 |
+
+## Troubleshooting
+
+**Script cannot reach docker**: confirm the executing user is in the `docker`
+group on `hp-mini-pc`, or that the agent's workspace has the docker socket
+mounted.
+
+**`datapack enable` returns "Unknown datapack"**: the pack directory was not
+copied correctly, or the name passed to `enable` does not match what was
+copied. Check the cleanup step — a previous failed run may have left a
+stale pack directory.
+
+**Function produces no output**: the function may use `tellraw` targeting
+a specific player. In an automated smoke context there are no players; use
+`say` or write to the server log instead when authoring test functions.
+
+**pack_format value to use**: for MC 26.1.2 the correct integer is `61`
+(data-pack format, not resource-pack format). Run
+`docker exec minecraft-papermc rcon-cli "data get entity @p DataVersion"`
+on a live player to confirm the data version if unsure. The smoke script
+resolves this automatically from the running server's version report.

--- a/docs/smoke-testing.md
+++ b/docs/smoke-testing.md
@@ -97,6 +97,52 @@ at the call site:
 | Host volume | `/home/jason/minecraft-server/data/` ↔ `/data/` |
 | `function-permission-level` | 2 |
 
+## Deploy runbook
+
+### When to deploy
+
+Deploy whenever a sub-issue that touches the datapack is marked `done` and CI is
+green. Never rely on a world zip built mid-flight — always deploy from merged HEAD.
+
+### 1. Deploy current HEAD to the live container
+
+```bash
+scripts/motfb-deploy.sh
+```
+
+This replaces `/data/Times_Square__NYC/datapacks/motfb` in the running container
+with the worktree's `output/motfb-datapack`, reloads datapacks, runs `motfb:init`,
+and confirms difficulty is Hard. Exits non-zero on any failure.
+
+### 2. Verify the live container matches HEAD
+
+```bash
+scripts/motfb-verify-deployed.sh
+```
+
+Diffs the live container's deployed datapack against `output/motfb-datapack`. Exits
+0 on a clean match, non-zero with a list of divergent files on mismatch.
+
+### 3. Rebuild the world zip (after all siblings land)
+
+Run this only after **all** sibling sub-issues have merged and CI is green:
+
+```bash
+scripts/motfb-package-world.sh <zip-name>
+# Example:
+scripts/motfb-package-world.sh motfb-phase-d-rev2
+```
+
+Pulls the live world from the container and writes
+`/home/jason/motfb-docs/<zip-name>.zip`, overwriting any existing file.
+
+### Mandatory close sequence for any datapack-touching sub-issue
+
+1. `scripts/motfb-deploy.sh` — push HEAD to container
+2. `scripts/motfb-verify-deployed.sh` — confirm match (must exit 0)
+3. Post completion comment; mark `in_review`
+4. World zip rebuild (`motfb-package-world.sh`) is deferred until all siblings land
+
 ## Troubleshooting
 
 **Script cannot reach docker**: confirm the executing user is in the `docker`

--- a/output/motfb-datapack/data/motfb/function/boss/on_death_candy_witch.mcfunction
+++ b/output/motfb-datapack/data/motfb/function/boss/on_death_candy_witch.mcfunction
@@ -1,0 +1,8 @@
+scoreboard players set #cinnabog_killed mall.flag 1
+fill -6 62 -230 -6 79 -216 minecraft:air replace minecraft:bedrock
+tag @a[tag=in_cinnabog] remove in_active_store
+function motfb:utils/give_coupon
+bossbar remove motfb:candywitch
+tag @a[tag=in_cinnabog] remove in_cinnabog
+tellraw @a [{"text":"[PA] ","color":"gray","italic":true},{"text":"Cinnabog is closed for renovation. The frosting has been contained.","color":"gold","italic":true}]
+playsound minecraft:block.note_block.chime ambient @a ~ ~ ~ 1 1.2

--- a/output/motfb-datapack/data/motfb/function/boss/on_death_exiled_saint.mcfunction
+++ b/output/motfb-datapack/data/motfb/function/boss/on_death_exiled_saint.mcfunction
@@ -1,0 +1,8 @@
+scoreboard players set #bathbody_killed mall.flag 1
+fill 6 62 -245 6 79 -231 minecraft:air replace minecraft:bedrock
+tag @a[tag=in_bathbody] remove in_active_store
+function motfb:utils/give_coupon
+bossbar remove motfb:exiledsaint
+tag @a[tag=in_bathbody] remove in_bathbody
+tellraw @a [{"text":"[PA] ","color":"gray","italic":true},{"text":"Bath and Bodywork is closed for renovation. The sanctum is at peace.","color":"gold","italic":true}]
+playsound minecraft:block.note_block.chime ambient @a ~ ~ ~ 1 1.2

--- a/output/motfb-datapack/data/motfb/function/boss/on_death_imp_swarm.mcfunction
+++ b/output/motfb-datapack/data/motfb/function/boss/on_death_imp_swarm.mcfunction
@@ -1,0 +1,12 @@
+execute if entity @e[tag=motfb_imp_2] run return fail
+execute if entity @e[tag=motfb_imp_3] run return fail
+execute if entity @e[tag=motfb_imp_4] run return fail
+execute if entity @e[tag=motfb_imp_5] run return fail
+scoreboard players set #spencers_killed mall.flag 1
+fill 6 62 -260 6 79 -246 minecraft:air replace minecraft:bedrock
+tag @a[tag=in_spencers] remove in_active_store
+function motfb:utils/give_coupon
+bossbar remove motfb:impswarm
+tag @a[tag=in_spencers] remove in_spencers
+tellraw @a [{"text":"[PA] ","color":"gray","italic":true},{"text":"Spencer's is closed for renovation. All five imps have been returned to the gift bags.","color":"gold","italic":true}]
+playsound minecraft:block.note_block.chime ambient @a ~ ~ ~ 1 1.2

--- a/output/motfb-datapack/data/motfb/function/boss/on_death_knot_god.mcfunction
+++ b/output/motfb-datapack/data/motfb/function/boss/on_death_knot_god.mcfunction
@@ -1,0 +1,8 @@
+scoreboard players set #pretzel_killed mall.flag 1
+fill 6 62 -230 6 79 -216 minecraft:air replace minecraft:bedrock
+tag @a[tag=in_pretzel] remove in_active_store
+function motfb:utils/give_coupon
+bossbar remove motfb:knotgod
+tag @a[tag=in_pretzel] remove in_pretzel
+tellraw @a [{"text":"[PA] ","color":"gray","italic":true},{"text":"Pretzel-Pretzel is closed for renovation. Janice is resting. Do not disturb Janice.","color":"gold","italic":true}]
+playsound minecraft:block.note_block.chime ambient @a ~ ~ ~ 1 1.2

--- a/output/motfb-datapack/data/motfb/function/boss/on_death_kraw.mcfunction
+++ b/output/motfb-datapack/data/motfb/function/boss/on_death_kraw.mcfunction
@@ -1,0 +1,8 @@
+scoreboard players set #kraw_killed mall.flag 1
+fill -6 62 -260 -6 79 -246 minecraft:air replace minecraft:bedrock
+tag @a[tag=in_kraw] remove in_active_store
+function motfb:utils/give_coupon
+bossbar remove motfb:kraw
+tag @a[tag=in_kraw] remove in_kraw
+tellraw @a [{"text":"[PA] ","color":"gray","italic":true},{"text":"Cluck-O-Mart is now closed for renovation. Thank you for shopping with us, sport.","color":"gold","italic":true}]
+playsound minecraft:block.note_block.chime ambient @a ~ ~ ~ 1 1.2

--- a/output/motfb-datapack/data/motfb/function/boss/on_death_pixel_lich.mcfunction
+++ b/output/motfb-datapack/data/motfb/function/boss/on_death_pixel_lich.mcfunction
@@ -1,0 +1,8 @@
+scoreboard players set #pixellich_killed mall.flag 1
+fill -6 62 -245 -6 79 -231 minecraft:air replace minecraft:bedrock
+tag @a[tag=in_pixellich] remove in_active_store
+function motfb:utils/give_coupon
+bossbar remove motfb:pixellich
+tag @a[tag=in_pixellich] remove in_pixellich
+tellraw @a [{"text":"[PA] ","color":"gray","italic":true},{"text":"GameStomp is closed for renovation. Please check your achievements. You have no achievements.","color":"gold","italic":true}]
+playsound minecraft:block.note_block.chime ambient @a ~ ~ ~ 1 1.2

--- a/output/motfb-datapack/data/motfb/function/boss/on_death_searz.mcfunction
+++ b/output/motfb-datapack/data/motfb/function/boss/on_death_searz.mcfunction
@@ -1,0 +1,8 @@
+scoreboard players set #searz_killed mall.flag 1
+fill -50 62 -261 50 79 -261 minecraft:air replace minecraft:bedrock
+tag @a[tag=in_searz] remove in_active_store
+function motfb:utils/give_coupon
+bossbar remove motfb:searz
+tag @a[tag=in_searz] remove in_searz
+tellraw @a [{"text":"[PA] ","color":"gray","italic":true},{"text":"SEARZ is closed for renovation across all three floors and all known dimensions.","color":"gold","italic":true}]
+playsound minecraft:block.note_block.chime ambient @a ~ ~ ~ 1 1.2

--- a/output/motfb-datapack/data/motfb/function/boss/on_death_speed_demon.mcfunction
+++ b/output/motfb-datapack/data/motfb/function/boss/on_death_speed_demon.mcfunction
@@ -1,0 +1,8 @@
+scoreboard players set #spunky_killed mall.flag 1
+fill 6 62 -215 6 79 -201 minecraft:air replace minecraft:bedrock
+tag @a[tag=in_spunky] remove in_active_store
+function motfb:utils/give_coupon
+bossbar remove motfb:speeddemon
+tag @a[tag=in_spunky] remove in_spunky
+tellraw @a [{"text":"[PA] ","color":"gray","italic":true},{"text":"Spunky's is closed for renovation. We have located the Speed Demon's soul in aisle 4.","color":"gold","italic":true}]
+playsound minecraft:block.note_block.chime ambient @a ~ ~ ~ 1 1.2

--- a/output/motfb-datapack/data/motfb/function/boss/on_death_stitch_lord.mcfunction
+++ b/output/motfb-datapack/data/motfb/function/boss/on_death_stitch_lord.mcfunction
@@ -1,0 +1,8 @@
+scoreboard players set #buildaboss_killed mall.flag 1
+fill -6 62 -215 -6 79 -201 minecraft:air replace minecraft:bedrock
+tag @a[tag=in_buildaboss] remove in_active_store
+function motfb:utils/give_coupon
+bossbar remove motfb:stitchlord
+tag @a[tag=in_buildaboss] remove in_buildaboss
+tellraw @a [{"text":"[PA] ","color":"gray","italic":true},{"text":"Build-A-Boss is closed for renovation. The workshop is at peace.","color":"gold","italic":true}]
+playsound minecraft:block.note_block.chime ambient @a ~ ~ ~ 1 1.2

--- a/output/motfb-datapack/data/motfb/function/boss/on_death_vampire_queen.mcfunction
+++ b/output/motfb-datapack/data/motfb/function/boss/on_death_vampire_queen.mcfunction
@@ -1,0 +1,8 @@
+scoreboard players set #hottopical_killed mall.flag 1
+fill -6 62 -200 -6 79 -186 minecraft:air replace minecraft:bedrock
+tag @a[tag=in_hottopical] remove in_active_store
+function motfb:utils/give_coupon
+bossbar remove motfb:vampirequeen
+tag @a[tag=in_hottopical] remove in_hottopical
+tellraw @a [{"text":"[PA] ","color":"gray","italic":true},{"text":"Hot-Topical is closed for renovation. The darkness has been renovated.","color":"gold","italic":true}]
+playsound minecraft:block.note_block.chime ambient @a ~ ~ ~ 1 1.2

--- a/output/motfb-datapack/data/motfb/function/boss/spawn_candy_witch.mcfunction
+++ b/output/motfb-datapack/data/motfb/function/boss/spawn_candy_witch.mcfunction
@@ -1,0 +1,15 @@
+execute as @a[x=-50,y=60,z=-230,dx=44,dy=20,dz=14] run tag @s add in_cinnabog
+execute as @a[x=-50,y=60,z=-230,dx=44,dy=20,dz=14] run tag @s add in_active_store
+fill -6 62 -230 -6 79 -216 minecraft:bedrock
+summon witch -28 65 -223 {Tags:["motfb_boss","motfb_candywitch_boss"],CustomName:'{"text":"The Candy Witch of Cinnabog","color":"light_purple"}',CustomNameVisible:1b,Health:90.0f,Attributes:[{Name:"minecraft:max_health",Base:90},{Name:"minecraft:movement_speed",Base:0.22}],PersistenceRequired:1b}
+bossbar add motfb:candywitch {"text":"The Candy Witch of Cinnabog","color":"dark_purple"}
+bossbar set motfb:candywitch players @a[tag=in_cinnabog]
+bossbar set motfb:candywitch max 90
+bossbar set motfb:candywitch value 90
+bossbar set motfb:candywitch color purple
+bossbar set motfb:candywitch style notched_10
+playsound minecraft:entity.witch.ambient hostile @a ~ ~ ~ 1 0.8
+title @a[tag=in_cinnabog] times 10 60 20
+title @a[tag=in_cinnabog] subtitle {"text":"SWEETER THAN SIN","color":"light_purple"}
+title @a[tag=in_cinnabog] title {"text":"THE CANDY WITCH","color":"dark_purple","bold":true}
+tellraw @a [{"text":"[PA] ","color":"gray","italic":true},{"text":"Cinnabog special: the frosting is complimentary. Everything else costs a piece of you.","color":"gold","italic":true}]

--- a/output/motfb-datapack/data/motfb/function/boss/spawn_exiled_saint.mcfunction
+++ b/output/motfb-datapack/data/motfb/function/boss/spawn_exiled_saint.mcfunction
@@ -1,0 +1,15 @@
+execute as @a[x=6,y=60,z=-245,dx=44,dy=20,dz=14] run tag @s add in_bathbody
+execute as @a[x=6,y=60,z=-245,dx=44,dy=20,dz=14] run tag @s add in_active_store
+fill 6 62 -245 6 79 -231 minecraft:bedrock
+summon evoker 28 65 -238 {Tags:["motfb_boss","motfb_exiledsaint_boss"],CustomName:'{"text":"The Exiled Saint of Bath & Bodywork","color":"white"}',CustomNameVisible:1b,Health:100.0f,Attributes:[{Name:"minecraft:max_health",Base:100},{Name:"minecraft:movement_speed",Base:0.25}],PersistenceRequired:1b}
+bossbar add motfb:exiledsaint {"text":"The Exiled Saint — Bath & Bodywork Sanctum","color":"white"}
+bossbar set motfb:exiledsaint players @a[tag=in_bathbody]
+bossbar set motfb:exiledsaint max 100
+bossbar set motfb:exiledsaint value 100
+bossbar set motfb:exiledsaint color white
+bossbar set motfb:exiledsaint style notched_10
+playsound minecraft:entity.evoker.ambient hostile @a ~ ~ ~ 1 0.9
+title @a[tag=in_bathbody] times 10 60 20
+title @a[tag=in_bathbody] subtitle {"text":"EXILED SAINT OF BATH & BODYWORK","color":"white"}
+title @a[tag=in_bathbody] title {"text":"THE EXILED SAINT","color":"white","bold":true}
+tellraw @a [{"text":"[PA] ","color":"gray","italic":true},{"text":"Bath and Bodywork Sanctum: all scents are complimentary. The vexes are not.","color":"gold","italic":true}]

--- a/output/motfb-datapack/data/motfb/function/boss/spawn_imp_swarm.mcfunction
+++ b/output/motfb-datapack/data/motfb/function/boss/spawn_imp_swarm.mcfunction
@@ -1,0 +1,19 @@
+execute as @a[x=6,y=60,z=-260,dx=44,dy=20,dz=14] run tag @s add in_spencers
+execute as @a[x=6,y=60,z=-260,dx=44,dy=20,dz=14] run tag @s add in_active_store
+fill 6 62 -260 6 79 -246 minecraft:bedrock
+summon vex 22 67 -253 {Tags:["motfb_boss","motfb_impswarm_boss","motfb_imp_1"],CustomName:'{"text":"Imp Swarm [1/5]","color":"aqua"}',CustomNameVisible:1b,Health:25.0f,Attributes:[{Name:"minecraft:max_health",Base:25}],Lifetime:-1,PersistenceRequired:1b}
+summon vex 28 69 -253 {Tags:["motfb_boss","motfb_imp_2"],CustomName:'{"text":"Imp Swarm [2/5]","color":"aqua"}',CustomNameVisible:1b,Health:25.0f,Attributes:[{Name:"minecraft:max_health",Base:25}],Lifetime:-1,PersistenceRequired:1b}
+summon vex 22 71 -256 {Tags:["motfb_boss","motfb_imp_3"],CustomName:'{"text":"Imp Swarm [3/5]","color":"aqua"}',CustomNameVisible:1b,Health:25.0f,Attributes:[{Name:"minecraft:max_health",Base:25}],Lifetime:-1,PersistenceRequired:1b}
+summon vex 28 67 -256 {Tags:["motfb_boss","motfb_imp_4"],CustomName:'{"text":"Imp Swarm [4/5]","color":"aqua"}',CustomNameVisible:1b,Health:25.0f,Attributes:[{Name:"minecraft:max_health",Base:25}],Lifetime:-1,PersistenceRequired:1b}
+summon vex 25 69 -250 {Tags:["motfb_boss","motfb_imp_5"],CustomName:'{"text":"Imp Swarm [5/5]","color":"aqua"}',CustomNameVisible:1b,Health:25.0f,Attributes:[{Name:"minecraft:max_health",Base:25}],Lifetime:-1,PersistenceRequired:1b}
+bossbar add motfb:impswarm {"text":"Imp Swarm — Spencer's Cursed Gifts","color":"blue"}
+bossbar set motfb:impswarm players @a[tag=in_spencers]
+bossbar set motfb:impswarm max 125
+bossbar set motfb:impswarm value 125
+bossbar set motfb:impswarm color blue
+bossbar set motfb:impswarm style notched_10
+playsound minecraft:entity.vex.ambient hostile @a ~ ~ ~ 1 1.2
+title @a[tag=in_spencers] times 10 60 20
+title @a[tag=in_spencers] subtitle {"text":"CURSED GIFTS — WHILE SUPPLIES LAST","color":"aqua"}
+title @a[tag=in_spencers] title {"text":"IMP SWARM","color":"blue","bold":true}
+tellraw @a [{"text":"[PA] ","color":"gray","italic":true},{"text":"Spencer's Cursed Gifts is having a five-for-one special. All of them are angry.","color":"gold","italic":true}]

--- a/output/motfb-datapack/data/motfb/function/boss/spawn_knot_god.mcfunction
+++ b/output/motfb-datapack/data/motfb/function/boss/spawn_knot_god.mcfunction
@@ -1,0 +1,15 @@
+execute as @a[x=6,y=60,z=-230,dx=44,dy=20,dz=14] run tag @s add in_pretzel
+execute as @a[x=6,y=60,z=-230,dx=44,dy=20,dz=14] run tag @s add in_active_store
+fill 6 62 -230 6 79 -216 minecraft:bedrock
+summon iron_golem 28 65 -223 {Tags:["motfb_boss","motfb_knotgod_boss"],CustomName:'{"text":"Janice, the Knot God","color":"gold"}',CustomNameVisible:1b,Health:140.0f,Attributes:[{Name:"minecraft:max_health",Base:140},{Name:"minecraft:attack_damage",Base:9},{Name:"minecraft:movement_speed",Base:0.18}],PersistenceRequired:1b}
+bossbar add motfb:knotgod {"text":"Janice — The Knot God of Pretzel-Pretzel","color":"gold"}
+bossbar set motfb:knotgod players @a[tag=in_pretzel]
+bossbar set motfb:knotgod max 140
+bossbar set motfb:knotgod value 140
+bossbar set motfb:knotgod color yellow
+bossbar set motfb:knotgod style notched_10
+playsound minecraft:entity.iron_golem.attack hostile @a ~ ~ ~ 1 0.7
+title @a[tag=in_pretzel] times 10 60 20
+title @a[tag=in_pretzel] subtitle {"text":"THE KNOT GOD OF PRETZEL-PRETZEL PRETZEL","color":"gold"}
+title @a[tag=in_pretzel] title {"text":"JANICE","color":"yellow","bold":true}
+tellraw @a [{"text":"[PA] ","color":"gray","italic":true},{"text":"Pretzel-Pretzel Pretzel: the pretzels are free. Janice is not.","color":"gold","italic":true}]

--- a/output/motfb-datapack/data/motfb/function/boss/spawn_kraw.mcfunction
+++ b/output/motfb-datapack/data/motfb/function/boss/spawn_kraw.mcfunction
@@ -1,5 +1,16 @@
 execute as @a[x=-50,y=60,z=-260,dx=44,dy=20,dz=14] run tag @s add in_kraw
 execute as @a[x=-50,y=60,z=-260,dx=44,dy=20,dz=14] run tag @s add in_active_store
+# F9: Flash the DANGER lamps on the arch frame before the door seals (visual pre-warning)
+setblock -7 62 -253 minecraft:redstone_lamp[lit=true]
+setblock -7 69 -253 minecraft:redstone_lamp[lit=true]
+# Place powered redstone blocks to keep lamps on (one block behind each lamp)
+setblock -8 62 -253 minecraft:redstone_block
+setblock -8 69 -253 minecraft:redstone_block
+# Neon sign color change: replace yellow arch segment with red (DANGER signal)
+fill -7 71 -251 -7 72 -253 minecraft:red_concrete
+# PA warning for door seal — give player a beat to see the arch light up
+tellraw @a[tag=in_kraw] [{"text":"[PA] ","color":"gray","italic":true},{"text":"ATTENTION: Cluck-O-Mart is now in BOGO LOCKDOWN MODE. Doors sealing for your dining safety.","color":"red","bold":true}]
+# Seal the entrance (bedrock wall at corridor boundary x=-6)
 fill -6 62 -260 -6 79 -246 minecraft:bedrock
 summon ghast -28 72 -253 {Tags:["motfb_boss","motfb_kraw_boss"],CustomName:'{"text":"Colonel Kraw, Wyvern Tyrant of the Drive-Thru","color":"red"}',CustomNameVisible:1b,Health:120.0f,Attributes:[{Name:"minecraft:max_health",Base:120},{Name:"minecraft:movement_speed",Base:0.06}],PersistenceRequired:1b}
 bossbar add motfb:kraw {"text":"Colonel Kraw — Wyvern Tyrant of the Drive-Thru","color":"red"}

--- a/output/motfb-datapack/data/motfb/function/boss/spawn_kraw.mcfunction
+++ b/output/motfb-datapack/data/motfb/function/boss/spawn_kraw.mcfunction
@@ -1,0 +1,15 @@
+execute as @a[x=-50,y=60,z=-260,dx=44,dy=20,dz=14] run tag @s add in_kraw
+execute as @a[x=-50,y=60,z=-260,dx=44,dy=20,dz=14] run tag @s add in_active_store
+fill -6 62 -260 -6 79 -246 minecraft:bedrock
+summon ghast -28 72 -253 {Tags:["motfb_boss","motfb_kraw_boss"],CustomName:'{"text":"Colonel Kraw, Wyvern Tyrant of the Drive-Thru","color":"red"}',CustomNameVisible:1b,Health:120.0f,Attributes:[{Name:"minecraft:max_health",Base:120},{Name:"minecraft:movement_speed",Base:0.06}],PersistenceRequired:1b}
+bossbar add motfb:kraw {"text":"Colonel Kraw — Wyvern Tyrant of the Drive-Thru","color":"red"}
+bossbar set motfb:kraw players @a[tag=in_kraw]
+bossbar set motfb:kraw max 120
+bossbar set motfb:kraw value 120
+bossbar set motfb:kraw color red
+bossbar set motfb:kraw style notched_10
+playsound minecraft:entity.ghast.warn hostile @a ~ ~ ~ 1 0.6
+title @a[tag=in_kraw] times 10 60 20
+title @a[tag=in_kraw] subtitle {"text":"WYVERN TYRANT OF THE DRIVE-THRU","color":"yellow"}
+title @a[tag=in_kraw] title {"text":"COLONEL KRAW","color":"red","bold":true}
+tellraw @a [{"text":"[PA] ","color":"gray","italic":true},{"text":"BOGO Cursed Nuggets! Limit one hero per coupon.","color":"gold","italic":true}]

--- a/output/motfb-datapack/data/motfb/function/boss/spawn_pixel_lich.mcfunction
+++ b/output/motfb-datapack/data/motfb/function/boss/spawn_pixel_lich.mcfunction
@@ -1,0 +1,15 @@
+execute as @a[x=-50,y=60,z=-245,dx=44,dy=20,dz=14] run tag @s add in_pixellich
+execute as @a[x=-50,y=60,z=-245,dx=44,dy=20,dz=14] run tag @s add in_active_store
+fill -6 62 -245 -6 79 -231 minecraft:bedrock
+summon husk -28 65 -238 {Tags:["motfb_boss","motfb_pixellich_boss"],CustomName:'{"text":"The Pixel Lich, Champion of the Loading Screen","color":"dark_green"}',CustomNameVisible:1b,Health:80.0f,Attributes:[{Name:"minecraft:max_health",Base:80},{Name:"minecraft:attack_damage",Base:5},{Name:"minecraft:armor",Base:4},{Name:"minecraft:movement_speed",Base:0.26}],ArmorItems:[{id:"minecraft:chainmail_boots",Count:1},{id:"minecraft:chainmail_leggings",Count:1},{id:"minecraft:chainmail_chestplate",Count:1},{id:"minecraft:chainmail_helmet",Count:1}],HandItems:[{id:"minecraft:stone_sword",Count:1,components:{"minecraft:enchantments":{"levels":{"minecraft:sharpness":1}}}},{}],PersistenceRequired:1b}
+bossbar add motfb:pixellich {"text":"The Pixel Lich — Champion of the Loading Screen","color":"green"}
+bossbar set motfb:pixellich players @a[tag=in_pixellich]
+bossbar set motfb:pixellich max 80
+bossbar set motfb:pixellich value 80
+bossbar set motfb:pixellich color green
+bossbar set motfb:pixellich style notched_10
+playsound minecraft:entity.husk.ambient hostile @a ~ ~ ~ 1 0.7
+title @a[tag=in_pixellich] times 10 60 20
+title @a[tag=in_pixellich] subtitle {"text":"CHAMPION OF THE LOADING SCREEN","color":"green"}
+title @a[tag=in_pixellich] title {"text":"THE PIXEL LICH","color":"dark_green","bold":true}
+tellraw @a [{"text":"[PA] ","color":"gray","italic":true},{"text":"Attention — GameStomp is now running a midnight tournament. Participation is not optional.","color":"gold","italic":true}]

--- a/output/motfb-datapack/data/motfb/function/boss/spawn_searz.mcfunction
+++ b/output/motfb-datapack/data/motfb/function/boss/spawn_searz.mcfunction
@@ -1,0 +1,15 @@
+execute as @a[x=-50,y=60,z=-280,dx=100,dy=20,dz=19] run tag @s add in_searz
+execute as @a[x=-50,y=60,z=-280,dx=100,dy=20,dz=19] run tag @s add in_active_store
+fill -50 62 -261 50 79 -261 minecraft:bedrock
+summon wither 0 68 -270 {Tags:["motfb_boss","motfb_searz_boss"],CustomName:'{"text":"Mama SEARZ, Forsaken Department Goddess (Floor 1)","color":"dark_red"}',CustomNameVisible:1b,Health:100.0f,Attributes:[{Name:"minecraft:max_health",Base:100},{Name:"minecraft:movement_speed",Base:0.1}],Invulnerable:0b,PersistenceRequired:1b,NoAI:0b}
+bossbar add motfb:searz {"text":"Mama SEARZ — Forsaken Department Goddess","color":"red"}
+bossbar set motfb:searz players @a[tag=in_searz]
+bossbar set motfb:searz max 300
+bossbar set motfb:searz value 300
+bossbar set motfb:searz color red
+bossbar set motfb:searz style notched_10
+playsound minecraft:entity.wither.spawn hostile @a ~ ~ ~ 2 0.5
+title @a[tag=in_searz] times 10 60 20
+title @a[tag=in_searz] subtitle {"text":"FORSAKEN DEPARTMENT GODDESS","color":"dark_red"}
+title @a[tag=in_searz] title {"text":"MAMA SEARZ","color":"red","bold":true}
+tellraw @a [{"text":"[PA] ","color":"gray","italic":true},{"text":"SEARZ is having a clearance event. All floors. All departments. She is all departments.","color":"gold","italic":true}]

--- a/output/motfb-datapack/data/motfb/function/boss/spawn_speed_demon.mcfunction
+++ b/output/motfb-datapack/data/motfb/function/boss/spawn_speed_demon.mcfunction
@@ -1,0 +1,16 @@
+execute as @a[x=6,y=60,z=-215,dx=44,dy=20,dz=14] run tag @s add in_spunky
+execute as @a[x=6,y=60,z=-215,dx=44,dy=20,dz=14] run tag @s add in_active_store
+fill 6 62 -215 6 79 -201 minecraft:bedrock
+summon vindicator 28 65 -208 {Tags:["motfb_boss","motfb_speeddemon_boss"],CustomName:'{"text":"The Speed Demon, Floor Manager of Spunkys","color":"aqua"}',CustomNameVisible:1b,Health:70.0f,Attributes:[{Name:"minecraft:max_health",Base:70},{Name:"minecraft:attack_damage",Base:6},{Name:"minecraft:movement_speed",Base:0.5}],HandItems:[{id:"minecraft:iron_sword",Count:1},{}],PersistenceRequired:1b}
+effect give @e[tag=motfb_speeddemon_boss] minecraft:speed 999999 2 true
+bossbar add motfb:speeddemon {"text":"The Speed Demon - Spunky's Sneakers","color":"aqua"}
+bossbar set motfb:speeddemon players @a[tag=in_spunky]
+bossbar set motfb:speeddemon max 70
+bossbar set motfb:speeddemon value 70
+bossbar set motfb:speeddemon color blue
+bossbar set motfb:speeddemon style notched_6
+playsound minecraft:entity.vindicator.ambient hostile @a ~ ~ ~ 1 1.5
+title @a[tag=in_spunky] times 10 60 20
+title @a[tag=in_spunky] subtitle {"text":"FLOOR MANAGER OF SPUNKYS SNEAKERS","color":"aqua"}
+title @a[tag=in_spunky] title {"text":"THE SPEED DEMON","color":"blue","bold":true}
+tellraw @a [{"text":"[PA] ","color":"gray","italic":true},{"text":"Spunkys Sneakers: these shoes were made for... this, specifically.","color":"gold","italic":true}]

--- a/output/motfb-datapack/data/motfb/function/boss/spawn_stitch_lord.mcfunction
+++ b/output/motfb-datapack/data/motfb/function/boss/spawn_stitch_lord.mcfunction
@@ -1,0 +1,15 @@
+execute as @a[x=-50,y=60,z=-215,dx=44,dy=20,dz=14] run tag @s add in_buildaboss
+execute as @a[x=-50,y=60,z=-215,dx=44,dy=20,dz=14] run tag @s add in_active_store
+fill -6 62 -215 -6 79 -201 minecraft:bedrock
+summon vindicator -28 65 -208 {Tags:["motfb_boss","motfb_stitchlord_boss"],CustomName:'{"text":"The Stitch Lord, Plushie Overlord","color":"yellow"}',CustomNameVisible:1b,Health:100.0f,Attributes:[{Name:"minecraft:max_health",Base:100},{Name:"minecraft:attack_damage",Base:7},{Name:"minecraft:armor",Base:2},{Name:"minecraft:movement_speed",Base:0.3}],HandItems:[{id:"minecraft:iron_axe",Count:1,components:{"minecraft:enchantments":{"levels":{"minecraft:sharpness":2}}}},{}],PersistenceRequired:1b}
+bossbar add motfb:stitchlord {"text":"The Stitch Lord — Plushie Overlord","color":"yellow"}
+bossbar set motfb:stitchlord players @a[tag=in_buildaboss]
+bossbar set motfb:stitchlord max 100
+bossbar set motfb:stitchlord value 100
+bossbar set motfb:stitchlord color yellow
+bossbar set motfb:stitchlord style notched_10
+playsound minecraft:entity.vindicator.ambient hostile @a ~ ~ ~ 1 0.9
+title @a[tag=in_buildaboss] times 10 60 20
+title @a[tag=in_buildaboss] subtitle {"text":"PLUSHIE OVERLORD","color":"yellow"}
+title @a[tag=in_buildaboss] title {"text":"THE STITCH LORD","color":"gold","bold":true}
+tellraw @a [{"text":"[PA] ","color":"gray","italic":true},{"text":"Build-A-Boss — customize your doom. Choose wisely. They chose wisely.","color":"gold","italic":true}]

--- a/output/motfb-datapack/data/motfb/function/boss/spawn_vampire_queen.mcfunction
+++ b/output/motfb-datapack/data/motfb/function/boss/spawn_vampire_queen.mcfunction
@@ -1,0 +1,15 @@
+execute as @a[x=-50,y=60,z=-200,dx=44,dy=20,dz=14] run tag @s add in_hottopical
+execute as @a[x=-50,y=60,z=-200,dx=44,dy=20,dz=14] run tag @s add in_active_store
+fill -6 62 -200 -6 79 -186 minecraft:bedrock
+summon wither_skeleton -28 65 -193 {Tags:["motfb_boss","motfb_vampirequeen_boss"],CustomName:'{"text":"The Vampire Queen of Hot-Topical","color":"dark_red"}',CustomNameVisible:1b,Health:100.0f,Attributes:[{Name:"minecraft:max_health",Base:100},{Name:"minecraft:attack_damage",Base:7},{Name:"minecraft:armor",Base:4},{Name:"minecraft:movement_speed",Base:0.28}],HandItems:[{id:"minecraft:stone_sword",Count:1,components:{"minecraft:enchantments":{"levels":{"minecraft:fire_aspect":1}}}},{}],PersistenceRequired:1b}
+bossbar add motfb:vampirequeen {"text":"The Vampire Queen — Hot-Topical","color":"red"}
+bossbar set motfb:vampirequeen players @a[tag=in_hottopical]
+bossbar set motfb:vampirequeen max 100
+bossbar set motfb:vampirequeen value 100
+bossbar set motfb:vampirequeen color red
+bossbar set motfb:vampirequeen style notched_10
+playsound minecraft:entity.wither_skeleton.ambient hostile @a ~ ~ ~ 1 0.9
+title @a[tag=in_hottopical] times 10 60 20
+title @a[tag=in_hottopical] subtitle {"text":"QUEEN OF HOT-TOPICAL","color":"dark_red"}
+title @a[tag=in_hottopical] title {"text":"THE VAMPIRE QUEEN","color":"red","bold":true}
+tellraw @a [{"text":"[PA] ","color":"gray","italic":true},{"text":"Hot-Topical clearance event — all darkness, half off. The darkness costs extra.","color":"gold","italic":true}]

--- a/output/motfb-datapack/data/motfb/function/bryan/architect_collapse.mcfunction
+++ b/output/motfb-datapack/data/motfb/function/bryan/architect_collapse.mcfunction
@@ -1,0 +1,4 @@
+kill @e[tag=motfb_bryan]
+scoreboard players set #party mall.bryan_phase 99
+particle minecraft:explosion_emitter 0 105 -212 5 5 5 0.1 10
+playsound minecraft:entity.generic.explode ambient @a ~ ~ ~ 3 0.5

--- a/output/motfb-datapack/data/motfb/function/bryan/hp_probe.mcfunction
+++ b/output/motfb-datapack/data/motfb/function/bryan/hp_probe.mcfunction
@@ -1,0 +1,5 @@
+execute store result score #party mall.bryan_hp run data get entity @e[tag=motfb_bryan,limit=1] Health
+execute if score #party mall.bryan_hp matches ..66 if score #party mall.bryan_phase matches 1 run function motfb:bryan/phase_2
+execute if score #party mall.bryan_hp matches ..33 if score #party mall.bryan_phase matches 2 run function motfb:bryan/phase_3
+execute if score #party mall.bryan_hp matches ..0 if score #party mall.bryan_phase matches 3 run function motfb:ending/b_voided_finalize
+execute if score #party mall.bryan_phase matches 0 if score #party mall.bryan_hp matches ..98 if entity @a[tag=has_contract] run function motfb:contract/attack

--- a/output/motfb-datapack/data/motfb/function/bryan/monologue.mcfunction
+++ b/output/motfb-datapack/data/motfb/function/bryan/monologue.mcfunction
@@ -1,0 +1,1 @@
+tellraw @a [{"text":"The Architect: ","color":"dark_red","bold":true},{"text":"\"Every mall has a final boss. I have ten. Every ending has an architect. You're looking at him. Now — let's see how you handle the renovation.\"","color":"red","italic":true}]

--- a/output/motfb-datapack/data/motfb/function/bryan/phase_2.mcfunction
+++ b/output/motfb-datapack/data/motfb/function/bryan/phase_2.mcfunction
@@ -1,0 +1,17 @@
+scoreboard players set #party mall.bryan_phase 2
+execute as @a run effect give @s minecraft:darkness 5 0 true
+weather thunder 30
+playsound minecraft:entity.lightning_bolt.thunder weather @a ~ ~ ~ 4 0.5
+title @a times 10 60 20
+title @a subtitle {"text":"Do you have ANY IDEA how tired I am?","color":"red","italic":true}
+title @a title {"text":"THE ARCHITECT OF ALL ENDINGS","color":"dark_red","bold":true}
+execute as @e[tag=motfb_bryan_phase1,limit=1] at @s run summon wither_skeleton ~ ~ ~ {Tags:["motfb_bryan","motfb_bryan_phase2"],CustomName:'{"text":"The Architect of All Endings","color":"dark_red","bold":true}',CustomNameVisible:1b,Health:66.0f,Attributes:[{Name:"minecraft:max_health",Base:66},{Name:"minecraft:attack_damage",Base:9},{Name:"minecraft:armor",Base:6},{Name:"minecraft:movement_speed",Base:0.32}],HandItems:[{id:"minecraft:netherite_sword",Count:1,components:{"minecraft:enchantments":{"levels":{"minecraft:sharpness":3}}}},{}],ArmorItems:[{id:"minecraft:netherite_boots",Count:1},{id:"minecraft:netherite_leggings",Count:1},{id:"minecraft:netherite_chestplate",Count:1},{id:"minecraft:netherite_helmet",Count:1}],PersistenceRequired:1b}
+kill @e[tag=motfb_bryan_phase1]
+bossbar remove motfb:bryan
+bossbar add motfb:bryan {"text":"The Architect of All Endings","color":"red"}
+bossbar set motfb:bryan players @a[tag=in_office]
+bossbar set motfb:bryan max 66
+bossbar set motfb:bryan value 66
+bossbar set motfb:bryan color red
+bossbar set motfb:bryan style notched_6
+schedule function motfb:bryan/monologue 40t

--- a/output/motfb-datapack/data/motfb/function/bryan/phase_3.mcfunction
+++ b/output/motfb-datapack/data/motfb/function/bryan/phase_3.mcfunction
@@ -1,0 +1,11 @@
+scoreboard players set #party mall.bryan_phase 3
+data merge entity @e[tag=motfb_bryan,limit=1] {NoAI:1b,Health:1.0f}
+title @a times 10 100 30
+title @a subtitle {"text":"\"...that's enough, sport.\"","color":"dark_purple","italic":true}
+title @a title {"text":"THE ARCHITECT FALLS","color":"dark_red","bold":true}
+playsound minecraft:entity.lightning_bolt.impact weather @a ~ ~ ~ 3 0.5
+function motfb:ending/b_bosses_depart
+function motfb:lostkid/wave_goodbye
+schedule function motfb:utils/teleport_escape 200t
+schedule function motfb:bryan/architect_collapse 300t
+schedule function motfb:ending/credits 400t

--- a/output/motfb-datapack/data/motfb/function/bryan/spawn_at_office.mcfunction
+++ b/output/motfb-datapack/data/motfb/function/bryan/spawn_at_office.mcfunction
@@ -1,0 +1,3 @@
+kill @e[tag=motfb_bryan]
+summon villager 0 102 -212 {Tags:["motfb_bryan","motfb_bryan_phase1"],CustomName:'[{"text":"Bryan","color":"dark_purple"},{"text":" (Mall Manager)","color":"gray","italic":true}]',CustomNameVisible:1b,VillagerData:{type:"plains",profession:"cleric",level:5},NoAI:1b,Silent:1b,Invulnerable:1b,PersistenceRequired:1b,Health:99.0f,Attributes:[{Name:"minecraft:max_health",Base:99},{Name:"minecraft:armor",Base:8}]}
+scoreboard players set #party mall.bryan_phase 0

--- a/output/motfb-datapack/data/motfb/function/build/f1_decor.mcfunction
+++ b/output/motfb-datapack/data/motfb/function/build/f1_decor.mcfunction
@@ -96,17 +96,17 @@ setblock 18 65 -131 minecraft:oak_slab[type=top]
 
 # Food court lighting: sea lanterns over tables at y=79 already covered by F2,
 # but add iron lanterns on chain posts in the food court center (warm amber)
-setblock -10 72 -138 minecraft:iron_chain[axis=y]
-setblock -10 71 -138 minecraft:iron_chain[axis=y]
+setblock -10 72 -138 minecraft:iron_bars
+setblock -10 71 -138 minecraft:iron_bars
 setblock -10 70 -138 minecraft:lantern[hanging=true]
-setblock 10 72 -138 minecraft:iron_chain[axis=y]
-setblock 10 71 -138 minecraft:iron_chain[axis=y]
+setblock 10 72 -138 minecraft:iron_bars
+setblock 10 71 -138 minecraft:iron_bars
 setblock 10 70 -138 minecraft:lantern[hanging=true]
-setblock -10 72 -132 minecraft:iron_chain[axis=y]
-setblock -10 71 -132 minecraft:iron_chain[axis=y]
+setblock -10 72 -132 minecraft:iron_bars
+setblock -10 71 -132 minecraft:iron_bars
 setblock -10 70 -132 minecraft:lantern[hanging=true]
-setblock 10 72 -132 minecraft:iron_chain[axis=y]
-setblock 10 71 -132 minecraft:iron_chain[axis=y]
+setblock 10 72 -132 minecraft:iron_bars
+setblock 10 71 -132 minecraft:iron_bars
 setblock 10 70 -132 minecraft:lantern[hanging=true]
 
 # Cinnabog kiosk overhang in food court (front-of-house counter visible from corridor)
@@ -156,8 +156,8 @@ setblock 9 76 -168 minecraft:polished_andesite_stairs[facing=south,half=bottom]
 setblock 9 77 -167 minecraft:polished_andesite_stairs[facing=south,half=bottom]
 setblock 9 78 -166 minecraft:polished_andesite_stairs[facing=south,half=bottom]
 # Chain detail on handrail side
-fill 7 66 -179 7 79 -166 minecraft:iron_chain[axis=y]
-fill 10 66 -179 10 79 -166 minecraft:iron_chain[axis=y]
+fill 7 66 -179 7 79 -166 minecraft:iron_bars
+fill 10 66 -179 10 79 -166 minecraft:iron_bars
 # Landing platform at top (floor 2 level y=82)
 fill 7 82 -166 10 82 -165 minecraft:polished_andesite_slab[type=top]
 

--- a/output/motfb-datapack/data/motfb/function/build/f1_decor.mcfunction
+++ b/output/motfb-datapack/data/motfb/function/build/f1_decor.mcfunction
@@ -1,0 +1,317 @@
+# =============================================================================
+# F1 — Mall Aesthetic Décor (MIN-160)
+# Adds food court section, atrium fountain, escalator suggestion, kiosk islands,
+# period décor (potted plants, neon sign frames), Hot-Topical corridor distinction,
+# and Kraw/Cluck-O-Mart pre-fight entrance archway (F9 pre-spawn state).
+#
+# Coordinate reference:
+#   Mall exterior: x=-50..50, z=-280..-100, y=59..115
+#   South entry/lobby: z=-101..-125
+#   Food court zone: z=-126..-149
+#   Fountain plaza: z=-150..-175
+#   Transition to stores: z=-176..-185
+#   Stores (west + east): z=-186..-260
+#   SEARZ: z=-261..-280
+# =============================================================================
+
+# =============================================================================
+# ATRIUM FOUNTAIN (§3.3 Setpiece 1) — central fountain plaza at z=-160..z=-163
+# 3×3 water source pool, sea lanterns beneath, polished andesite rim
+# =============================================================================
+
+# Sea lanterns on pool floor (light rising through water)
+fill -1 63 -163 1 63 -161 minecraft:sea_lantern
+# Water source blocks (3×3, 1 deep)
+fill -1 64 -163 1 64 -161 minecraft:water
+# Polished andesite rim (raised 1 block above floor as pool wall)
+fill -3 64 -165 3 64 -165 minecraft:polished_andesite
+fill -3 64 -159 3 64 -159 minecraft:polished_andesite
+fill -3 64 -165 -3 64 -159 minecraft:polished_andesite
+fill 3 64 -165 3 64 -159 minecraft:polished_andesite
+fill -3 65 -165 3 65 -165 minecraft:polished_andesite
+fill -3 65 -159 3 65 -159 minecraft:polished_andesite
+fill -3 65 -165 -3 65 -159 minecraft:polished_andesite
+fill 3 65 -165 3 65 -159 minecraft:polished_andesite
+# Corner cap: smooth quartz pillars at fountain corners
+setblock -3 66 -165 minecraft:quartz_pillar[axis=y]
+setblock 3 66 -165 minecraft:quartz_pillar[axis=y]
+setblock -3 66 -159 minecraft:quartz_pillar[axis=y]
+setblock 3 66 -159 minecraft:quartz_pillar[axis=y]
+# Plaza floor around fountain: polished andesite "grout" expanding from rim
+fill -5 64 -167 5 64 -157 minecraft:polished_andesite
+fill -3 64 -165 3 64 -159 minecraft:smooth_quartz
+fill -1 64 -163 1 64 -161 minecraft:water
+
+# =============================================================================
+# FOOD COURT ZONE (z=-126..-149): tiled floor + seating area
+# Saturated 90s neon tile pattern per owner decision §0.3
+# =============================================================================
+
+# Base tile: orange terracotta (food court zone x=-24..24)
+fill -24 64 -149 24 64 -126 minecraft:orange_terracotta
+
+# White concrete grout grid (every 4 blocks in z)
+fill -24 64 -148 24 64 -148 minecraft:white_concrete
+fill -24 64 -144 24 64 -144 minecraft:white_concrete
+fill -24 64 -140 24 64 -140 minecraft:white_concrete
+fill -24 64 -136 24 64 -136 minecraft:white_concrete
+fill -24 64 -132 24 64 -132 minecraft:white_concrete
+fill -24 64 -128 24 64 -128 minecraft:white_concrete
+# White concrete grout grid (every 4 blocks in x)
+fill -24 64 -149 -24 64 -126 minecraft:white_concrete
+fill -20 64 -149 -20 64 -126 minecraft:white_concrete
+fill -16 64 -149 -16 64 -126 minecraft:white_concrete
+fill -12 64 -149 -12 64 -126 minecraft:white_concrete
+fill -8 64 -149 -8 64 -126 minecraft:white_concrete
+fill -4 64 -149 -4 64 -126 minecraft:white_concrete
+fill 0 64 -149 0 64 -126 minecraft:white_concrete
+fill 4 64 -149 4 64 -126 minecraft:white_concrete
+fill 8 64 -149 8 64 -126 minecraft:white_concrete
+fill 12 64 -149 12 64 -126 minecraft:white_concrete
+fill 16 64 -149 16 64 -126 minecraft:white_concrete
+fill 20 64 -149 20 64 -126 minecraft:white_concrete
+fill 24 64 -149 24 64 -126 minecraft:white_concrete
+
+# Food court seating area: oak slabs as table surfaces (1 block above floor)
+# Table 1 (Lore §2 Tell #5 — Table 8)
+setblock -18 65 -140 minecraft:oak_slab[type=top]
+setblock -16 65 -140 minecraft:oak_slab[type=top]
+setblock -18 65 -138 minecraft:oak_slab[type=top]
+setblock -16 65 -138 minecraft:oak_slab[type=top]
+# Table 2
+setblock -18 65 -133 minecraft:oak_slab[type=top]
+setblock -16 65 -133 minecraft:oak_slab[type=top]
+setblock -18 65 -131 minecraft:oak_slab[type=top]
+setblock -16 65 -131 minecraft:oak_slab[type=top]
+# Table 3 (east side)
+setblock 16 65 -140 minecraft:oak_slab[type=top]
+setblock 18 65 -140 minecraft:oak_slab[type=top]
+setblock 16 65 -138 minecraft:oak_slab[type=top]
+setblock 18 65 -138 minecraft:oak_slab[type=top]
+# Table 4
+setblock 16 65 -133 minecraft:oak_slab[type=top]
+setblock 18 65 -133 minecraft:oak_slab[type=top]
+setblock 16 65 -131 minecraft:oak_slab[type=top]
+setblock 18 65 -131 minecraft:oak_slab[type=top]
+
+# Food court lighting: sea lanterns over tables at y=79 already covered by F2,
+# but add iron lanterns on chain posts in the food court center (warm amber)
+setblock -10 72 -138 minecraft:iron_chain[axis=y]
+setblock -10 71 -138 minecraft:iron_chain[axis=y]
+setblock -10 70 -138 minecraft:lantern[hanging=true]
+setblock 10 72 -138 minecraft:iron_chain[axis=y]
+setblock 10 71 -138 minecraft:iron_chain[axis=y]
+setblock 10 70 -138 minecraft:lantern[hanging=true]
+setblock -10 72 -132 minecraft:iron_chain[axis=y]
+setblock -10 71 -132 minecraft:iron_chain[axis=y]
+setblock -10 70 -132 minecraft:lantern[hanging=true]
+setblock 10 72 -132 minecraft:iron_chain[axis=y]
+setblock 10 71 -132 minecraft:iron_chain[axis=y]
+setblock 10 70 -132 minecraft:lantern[hanging=true]
+
+# Cinnabog kiosk overhang in food court (front-of-house counter visible from corridor)
+# This is the food court facing side of Cinnabog (west side z=-216..-230 boundary)
+# Accent orange concrete fascia sign visible to food court walkers
+fill -14 67 -185 -8 69 -185 minecraft:orange_concrete
+fill -14 70 -185 -8 70 -185 minecraft:oak_slab[type=top]
+
+# =============================================================================
+# ESCALATOR SUGGESTION (§1.0 note) — between food court and north store corridor
+# Rough-build: stair+slabs with andesite frame, running east side of corridor
+# Goes from floor 1 (y=65) up to floor 2 (y=82) via stair blocks at x=7..10
+# =============================================================================
+
+# Andesite frame pillars
+fill 7 65 -180 7 80 -180 minecraft:polished_andesite
+fill 10 65 -180 10 80 -180 minecraft:polished_andesite
+fill 7 65 -165 7 80 -165 minecraft:polished_andesite
+fill 10 65 -165 10 80 -165 minecraft:polished_andesite
+# Escalator stair treads (ascending north to south, each tread raises 1 y per z)
+setblock 8 65 -179 minecraft:polished_andesite_stairs[facing=south,half=bottom]
+setblock 8 66 -178 minecraft:polished_andesite_stairs[facing=south,half=bottom]
+setblock 8 67 -177 minecraft:polished_andesite_stairs[facing=south,half=bottom]
+setblock 8 68 -176 minecraft:polished_andesite_stairs[facing=south,half=bottom]
+setblock 8 69 -175 minecraft:polished_andesite_stairs[facing=south,half=bottom]
+setblock 8 70 -174 minecraft:polished_andesite_stairs[facing=south,half=bottom]
+setblock 8 71 -173 minecraft:polished_andesite_stairs[facing=south,half=bottom]
+setblock 8 72 -172 minecraft:polished_andesite_stairs[facing=south,half=bottom]
+setblock 8 73 -171 minecraft:polished_andesite_stairs[facing=south,half=bottom]
+setblock 8 74 -170 minecraft:polished_andesite_stairs[facing=south,half=bottom]
+setblock 8 75 -169 minecraft:polished_andesite_stairs[facing=south,half=bottom]
+setblock 8 76 -168 minecraft:polished_andesite_stairs[facing=south,half=bottom]
+setblock 8 77 -167 minecraft:polished_andesite_stairs[facing=south,half=bottom]
+setblock 8 78 -166 minecraft:polished_andesite_stairs[facing=south,half=bottom]
+setblock 9 65 -179 minecraft:polished_andesite_stairs[facing=south,half=bottom]
+setblock 9 66 -178 minecraft:polished_andesite_stairs[facing=south,half=bottom]
+setblock 9 67 -177 minecraft:polished_andesite_stairs[facing=south,half=bottom]
+setblock 9 68 -176 minecraft:polished_andesite_stairs[facing=south,half=bottom]
+setblock 9 69 -175 minecraft:polished_andesite_stairs[facing=south,half=bottom]
+setblock 9 70 -174 minecraft:polished_andesite_stairs[facing=south,half=bottom]
+setblock 9 71 -173 minecraft:polished_andesite_stairs[facing=south,half=bottom]
+setblock 9 72 -172 minecraft:polished_andesite_stairs[facing=south,half=bottom]
+setblock 9 73 -171 minecraft:polished_andesite_stairs[facing=south,half=bottom]
+setblock 9 74 -170 minecraft:polished_andesite_stairs[facing=south,half=bottom]
+setblock 9 75 -169 minecraft:polished_andesite_stairs[facing=south,half=bottom]
+setblock 9 76 -168 minecraft:polished_andesite_stairs[facing=south,half=bottom]
+setblock 9 77 -167 minecraft:polished_andesite_stairs[facing=south,half=bottom]
+setblock 9 78 -166 minecraft:polished_andesite_stairs[facing=south,half=bottom]
+# Chain detail on handrail side
+fill 7 66 -179 7 79 -166 minecraft:iron_chain[axis=y]
+fill 10 66 -179 10 79 -166 minecraft:iron_chain[axis=y]
+# Landing platform at top (floor 2 level y=82)
+fill 7 82 -166 10 82 -165 minecraft:polished_andesite_slab[type=top]
+
+# =============================================================================
+# KIOSK ISLANDS (§1.0 F1 requirement) — concourse kiosk carts every 16 blocks
+# Kiosks are 3×2 smooth quartz + item frame "display" surfaces
+# =============================================================================
+
+# Kiosk A (z=-185, center corridor)
+fill -2 65 -186 2 65 -184 minecraft:smooth_quartz
+fill -2 66 -186 2 66 -184 minecraft:smooth_quartz_slab[type=top]
+setblock 0 67 -185 minecraft:lantern
+
+# Kiosk B (z=-169)
+fill -2 65 -170 2 65 -168 minecraft:smooth_quartz
+fill -2 66 -170 2 66 -168 minecraft:smooth_quartz_slab[type=top]
+setblock 0 67 -169 minecraft:lantern
+
+# Kiosk C (z=-153)
+fill -2 65 -154 2 65 -152 minecraft:smooth_quartz
+fill -2 66 -154 2 66 -152 minecraft:smooth_quartz_slab[type=top]
+setblock 0 67 -153 minecraft:lantern
+
+# =============================================================================
+# PERIOD DÉCOR — potted plants throughout corridor every 12 blocks
+# =============================================================================
+
+setblock -5 65 -120 minecraft:flower_pot
+setblock 5 65 -120 minecraft:flower_pot
+setblock -5 65 -132 minecraft:flower_pot
+setblock 5 65 -132 minecraft:flower_pot
+setblock -5 65 -144 minecraft:flower_pot
+setblock 5 65 -144 minecraft:flower_pot
+setblock -5 65 -156 minecraft:flower_pot
+setblock 5 65 -156 minecraft:flower_pot
+setblock -5 65 -168 minecraft:flower_pot
+setblock 5 65 -168 minecraft:flower_pot
+setblock -5 65 -180 minecraft:flower_pot
+setblock 5 65 -180 minecraft:flower_pot
+
+# Potted plants on column tops (if any exist at the corridor widening points)
+setblock -6 65 -230 minecraft:flower_pot
+setblock 6 65 -230 minecraft:flower_pot
+setblock -6 65 -215 minecraft:flower_pot
+setblock 6 65 -215 minecraft:flower_pot
+
+# =============================================================================
+# NEON SIGN FRAMES — colored glass + light block (stained glass backlit by
+# sea lanterns) mounted above store arch height (y=72-74)
+# Each store gets a neon accent band in its palette color
+# =============================================================================
+
+# Hot-Topical neon: purple stained glass strip above corridor entrance y=72-73
+fill -5 72 -186 5 73 -186 minecraft:purple_stained_glass
+fill -5 74 -186 5 74 -186 minecraft:purple_stained_glass_pane
+# Back-light sea lanterns at y=75 behind the glass
+fill -5 75 -186 5 75 -186 minecraft:sea_lantern
+
+# Cluck-O-Mart neon (west side corridor-facing): red/yellow at x=-7, z=-253
+fill -7 72 -260 -7 74 -246 minecraft:red_stained_glass
+fill -7 75 -260 -7 75 -246 minecraft:sea_lantern
+
+# Spencer's neon (east side): orange/lime at x=7, z=-253
+fill 7 72 -260 7 74 -246 minecraft:orange_stained_glass
+fill 7 75 -260 7 75 -246 minecraft:sea_lantern
+
+# GameStomp neon: cyan stained glass (display windows) at x=-7, z=-238
+fill -7 68 -245 -7 71 -231 minecraft:cyan_stained_glass
+fill -7 72 -245 -7 74 -231 minecraft:dark_oak_planks
+setblock -7 75 -238 minecraft:sea_lantern
+
+# Bath & Body neon: lavender stained glass at x=7, z=-238
+fill 7 68 -245 7 71 -231 minecraft:purple_stained_glass_pane
+fill 7 72 -245 7 74 -231 minecraft:white_concrete
+setblock 7 75 -238 minecraft:sea_lantern
+
+# =============================================================================
+# HOT-TOPICAL CORRIDOR (§1.5) — distinct eggplant aesthetic zone
+# The corridor segment z=-186..-200 (connecting to Hot-Topical) must read
+# as a separate aesthetic zone. Purple terracotta walls + black ceiling.
+# =============================================================================
+
+# Corridor walls (y=65..78) in the Hot-Topical approach zone (x=-5..5)
+fill -5 65 -186 -5 78 -200 minecraft:purple_terracotta
+fill 5 65 -186 5 78 -200 minecraft:purple_terracotta
+fill -5 65 -200 5 65 -200 minecraft:purple_terracotta
+# Black concrete ceiling patch over corridor at y=79 (overrides F2 troffer at these z levels)
+fill -5 79 -200 5 79 -187 minecraft:black_concrete
+# Soul lanterns at y=78 in the Hot-Topical corridor (cold blue-white)
+setblock 0 78 -189 minecraft:soul_lantern
+setblock 0 78 -194 minecraft:soul_lantern
+setblock 0 78 -199 minecraft:soul_lantern
+setblock -4 78 -193 minecraft:soul_lantern
+setblock 4 78 -193 minecraft:soul_lantern
+
+# Vampire Queen jewelry case (coffin-shaped centerpiece §1.5)
+fill -30 65 -193 -28 65 -191 minecraft:dark_oak_slab[type=top]
+fill -30 66 -193 -28 66 -191 minecraft:glass_pane
+fill -30 64 -193 -28 64 -191 minecraft:purple_glazed_terracotta
+
+# =============================================================================
+# F9 PRE-FIGHT: CLUCK-O-MART ENTRANCE ARCHWAY
+# Distinctive red/yellow arch frame at x=-7 (corridor side of Kraw door)
+# so Jason can see WHERE the entrance is before the bedrock wall seals it.
+# The visual state CHANGE (lamps) happens in spawn_kraw.mcfunction.
+# =============================================================================
+
+# Arch column pillars (red concrete) at z=-260 and z=-246 corners, y=62..69
+fill -7 62 -260 -7 69 -260 minecraft:red_concrete
+fill -7 62 -246 -7 69 -246 minecraft:red_concrete
+# Arch lintel (yellow concrete) spanning z=-260..-246 at y=70
+fill -7 70 -260 -7 70 -246 minecraft:yellow_concrete
+# Neon "CLUCK-O-MART" sign band: red/yellow alternating at y=71-72
+fill -7 71 -260 -7 72 -252 minecraft:red_concrete
+fill -7 71 -251 -7 72 -246 minecraft:yellow_concrete
+# Glowstone backlight behind sign (at y=73)
+fill -7 73 -260 -7 73 -246 minecraft:glowstone
+# Redstone lamp "DANGER" indicators (dormant until spawn_kraw fires)
+setblock -7 62 -253 minecraft:redstone_lamp
+setblock -7 69 -253 minecraft:redstone_lamp
+# Door frame on sides (dark oak for the "opening" feel)
+fill -7 62 -259 -7 69 -247 minecraft:dark_oak_planks
+fill -8 62 -260 -8 69 -246 minecraft:dark_oak_planks
+
+# Build-A-Boss entrance archway (west side, x=-7, z=-201..-215): pastel pink frame
+fill -7 62 -215 -7 69 -215 minecraft:pink_concrete
+fill -7 62 -201 -7 69 -201 minecraft:pink_concrete
+fill -7 70 -215 -7 70 -201 minecraft:lime_concrete
+fill -7 71 -214 -7 71 -202 minecraft:light_blue_concrete
+
+# GameStomp entrance archway (x=-7, z=-231..-245): dark oak frame
+fill -7 62 -245 -7 69 -245 minecraft:dark_oak_planks
+fill -7 62 -231 -7 69 -231 minecraft:dark_oak_planks
+fill -7 70 -245 -7 70 -231 minecraft:blackstone_slab[type=top]
+
+# Cinnabog entrance archway (x=-7, z=-216..-230): warm sandstone frame
+fill -7 62 -230 -7 69 -230 minecraft:smooth_sandstone
+fill -7 62 -216 -7 69 -216 minecraft:smooth_sandstone
+fill -7 70 -230 -7 70 -216 minecraft:orange_concrete
+
+# East side store archways (x=7)
+# Spencer's entrance
+fill 7 62 -260 7 69 -260 minecraft:orange_concrete
+fill 7 62 -246 7 69 -246 minecraft:orange_concrete
+fill 7 70 -260 7 70 -246 minecraft:lime_concrete
+# Bath & Body entrance
+fill 7 62 -245 7 69 -245 minecraft:smooth_quartz
+fill 7 62 -231 7 69 -231 minecraft:smooth_quartz
+fill 7 70 -245 7 70 -231 minecraft:white_concrete
+# Knot God / Pretzel entrance
+fill 7 62 -230 7 69 -230 minecraft:smooth_sandstone
+fill 7 62 -216 7 69 -216 minecraft:smooth_sandstone
+fill 7 70 -230 7 70 -216 minecraft:yellow_concrete
+# Spunky's Sneakers entrance
+fill 7 62 -215 7 69 -215 minecraft:white_concrete
+fill 7 62 -201 7 69 -201 minecraft:white_concrete
+fill 7 70 -215 7 70 -201 minecraft:orange_concrete

--- a/output/motfb-datapack/data/motfb/function/build/f1_floors.mcfunction
+++ b/output/motfb-datapack/data/motfb/function/build/f1_floors.mcfunction
@@ -170,3 +170,32 @@ fill -49 65 -260 -49 66 -246 minecraft:red_concrete
 fill -49 65 -246 -7 66 -246 minecraft:red_concrete
 fill -49 65 -260 -7 66 -260 minecraft:red_concrete
 fill -7 65 -260 -7 66 -246 minecraft:red_concrete
+
+# --- EAST STORE WALL BASEBOARDS (y=65-66) ---
+# Spencer's Cursed Gifts east store: orange/yellow concrete lower walls §1.6
+fill 49 65 -260 49 66 -246 minecraft:orange_concrete
+fill 49 65 -246 7 66 -246 minecraft:orange_concrete
+fill 49 65 -260 7 66 -260 minecraft:orange_concrete
+fill 7 65 -260 7 66 -246 minecraft:orange_concrete
+
+# Bath & Bodywork Sanctum east store: white concrete lower walls §1.7
+fill 49 65 -245 49 66 -231 minecraft:white_concrete
+fill 49 65 -231 7 66 -231 minecraft:white_concrete
+fill 49 65 -245 7 66 -245 minecraft:white_concrete
+fill 7 65 -245 7 66 -231 minecraft:white_concrete
+# Lavender stained glass accent (inner band §1.7)
+fill 48 65 -244 8 66 -232 minecraft:smooth_quartz
+
+# Pretzel-Pretzel Pretzel east store: smooth sandstone lower walls §1.8
+fill 49 65 -230 49 66 -216 minecraft:smooth_sandstone
+fill 49 65 -216 7 66 -216 minecraft:smooth_sandstone
+fill 49 65 -230 7 66 -230 minecraft:smooth_sandstone
+fill 7 65 -230 7 66 -216 minecraft:smooth_sandstone
+
+# Spunky's Sneakers east store: white concrete lower walls §1.9
+fill 49 65 -215 49 66 -201 minecraft:white_concrete
+fill 49 65 -201 7 66 -201 minecraft:white_concrete
+fill 49 65 -215 7 66 -215 minecraft:white_concrete
+fill 7 65 -215 7 66 -201 minecraft:white_concrete
+# Orange accent stripe at mid-wall height §1.9
+fill 48 65 -214 8 66 -202 minecraft:orange_concrete

--- a/output/motfb-datapack/data/motfb/function/build/f1_floors.mcfunction
+++ b/output/motfb-datapack/data/motfb/function/build/f1_floors.mcfunction
@@ -1,0 +1,172 @@
+# =============================================================================
+# F1 — Per-Store Floor Differentiation (MIN-160)
+# Each of the 10 store bays gets a distinct floor material matching §1.x palette.
+# Corridor floor (y=64, x=-6..6) keeps smooth quartz per §1.0.
+# Store interiors fill at y=64 only (no structural risk).
+# =============================================================================
+
+# --- WEST STORES (x=-49..-7) ---
+
+# Cluck-O-Mart / Colonel Kraw (z=-246..-260): yellow terracotta dining, red concrete kitchen §1.2
+fill -49 64 -260 -7 64 -260 minecraft:yellow_terracotta
+fill -49 64 -259 -7 64 -253 minecraft:yellow_terracotta
+fill -49 64 -252 -7 64 -246 minecraft:red_concrete
+# Kitchen fryer pit trace (red concrete back section behind boss spawn z=-256..-258)
+fill -35 64 -258 -20 64 -253 minecraft:red_concrete
+
+# GameStomp / Pixel Lich (z=-231..-245): dark oak planks §1.4
+fill -49 64 -245 -7 64 -231 minecraft:dark_oak_planks
+# Checkout area (light gray concrete near corridor entrance x=-15..-7)
+fill -15 64 -245 -7 64 -231 minecraft:gray_concrete
+
+# Cinnabog & Co. / Candy Witch (z=-216..-230): birch planks with brown terracotta accents §1.3
+fill -49 64 -230 -7 64 -216 minecraft:birch_planks
+# Counter zone oak trapdoor mat (near entrance x=-10..-7)
+fill -12 64 -225 -7 64 -221 minecraft:oak_trapdoor[facing=north,open=false,half=bottom]
+
+# Build-A-Boss / Stitch Lord (z=-201..-215): pink concrete with lime inset dots §1.1
+fill -49 64 -215 -7 64 -201 minecraft:pink_concrete
+# Lime dot pattern every 4 blocks (playmat feel)
+fill -45 64 -215 -45 64 -215 minecraft:lime_concrete
+fill -41 64 -211 -41 64 -211 minecraft:lime_concrete
+fill -37 64 -207 -37 64 -207 minecraft:lime_concrete
+fill -33 64 -203 -33 64 -203 minecraft:lime_concrete
+fill -29 64 -215 -29 64 -215 minecraft:lime_concrete
+fill -25 64 -211 -25 64 -211 minecraft:lime_concrete
+fill -21 64 -207 -21 64 -207 minecraft:lime_concrete
+fill -17 64 -203 -17 64 -203 minecraft:lime_concrete
+fill -13 64 -211 -13 64 -211 minecraft:lime_concrete
+fill -9 64 -205 -9 64 -205 minecraft:lime_concrete
+
+# Hot-Topical / Vampire Queen (z=-186..-200): black concrete with deepslate tile §1.5
+fill -49 64 -200 -7 64 -186 minecraft:black_concrete
+# Fitting room threshold: crimson planks strip (near back of store x=-35..-20)
+fill -35 64 -196 -20 64 -190 minecraft:crimson_planks
+
+# --- EAST STORES (x=7..49) ---
+
+# Spencer's Cursed Gifts / Imp Swarm (z=-246..-260): multi-color chaos per §1.6
+# Rotating concrete colors (3-block chunks)
+fill 7 64 -260 17 64 -246 minecraft:orange_concrete
+fill 18 64 -260 27 64 -246 minecraft:yellow_concrete
+fill 28 64 -260 37 64 -246 minecraft:cyan_concrete
+fill 38 64 -260 49 64 -246 minecraft:lime_concrete
+# Center aisle stays light gray
+fill 7 64 -255 20 64 -252 minecraft:light_gray_concrete
+# Pentagram center (single lime block where Imp Swarm spawns)
+fill 25 64 -253 25 64 -253 minecraft:lime_concrete
+
+# Bath & Bodywork Sanctum / Exiled Saint (z=-231..-245): white concrete with quartz, pink insets §1.7
+fill 7 64 -245 49 64 -231 minecraft:white_concrete
+# Light pink terracotta insets (1×1 every 4 blocks)
+fill 11 64 -245 11 64 -245 minecraft:pink_terracotta
+fill 15 64 -241 15 64 -241 minecraft:pink_terracotta
+fill 19 64 -237 19 64 -237 minecraft:pink_terracotta
+fill 23 64 -233 23 64 -233 minecraft:pink_terracotta
+fill 27 64 -245 27 64 -245 minecraft:pink_terracotta
+fill 31 64 -241 31 64 -241 minecraft:pink_terracotta
+fill 35 64 -237 35 64 -237 minecraft:pink_terracotta
+fill 39 64 -233 39 64 -233 minecraft:pink_terracotta
+fill 43 64 -241 43 64 -241 minecraft:pink_terracotta
+
+# Pretzel-Pretzel Pretzel / Knot God (z=-216..-230): birch planks with stone brick border §1.8
+fill 7 64 -230 49 64 -216 minecraft:birch_planks
+# Kiosk border: dark oak around the kiosk zone (center area)
+fill 22 64 -228 32 64 -218 minecraft:dark_oak_planks
+fill 24 64 -226 30 64 -220 minecraft:birch_planks
+
+# Spunky's Sneakers / Speed Demon (z=-201..-215): white concrete with orange center logo §1.9
+fill 7 64 -215 49 64 -201 minecraft:white_concrete
+# Light gray concrete grid lines (4-block intervals)
+fill 7 64 -211 49 64 -211 minecraft:light_gray_concrete
+fill 7 64 -207 49 64 -207 minecraft:light_gray_concrete
+fill 7 64 -203 49 64 -203 minecraft:light_gray_concrete
+fill 25 64 -215 25 64 -201 minecraft:light_gray_concrete
+fill 35 64 -215 35 64 -201 minecraft:light_gray_concrete
+# Orange concrete inset logo panel (center of store)
+fill 27 64 -213 33 64 -203 minecraft:orange_concrete
+
+# --- SEARZ Anchor (full width x=-49..49, z=-261..-279): polished granite §1.10 ---
+fill -49 64 -279 49 64 -261 minecraft:polished_granite
+# Cracked stone bricks scattered (damage aesthetic — only in SEARZ)
+fill -40 64 -275 -35 64 -270 minecraft:cracked_stone_bricks
+fill 30 64 -275 38 64 -268 minecraft:cracked_stone_bricks
+fill -20 64 -265 -10 64 -261 minecraft:cracked_stone_bricks
+
+# --- Corridor floor (x=-6..6): keep smooth quartz per §1.0 but add polished andesite grout lines ---
+# Grout lines every 4 blocks in z
+fill -6 64 -279 6 64 -279 minecraft:polished_andesite
+fill -6 64 -275 6 64 -275 minecraft:polished_andesite
+fill -6 64 -271 6 64 -271 minecraft:polished_andesite
+fill -6 64 -267 6 64 -267 minecraft:polished_andesite
+fill -6 64 -263 6 64 -263 minecraft:polished_andesite
+fill -6 64 -259 6 64 -259 minecraft:polished_andesite
+fill -6 64 -255 6 64 -255 minecraft:polished_andesite
+fill -6 64 -251 6 64 -251 minecraft:polished_andesite
+fill -6 64 -247 6 64 -247 minecraft:polished_andesite
+fill -6 64 -243 6 64 -243 minecraft:polished_andesite
+fill -6 64 -239 6 64 -239 minecraft:polished_andesite
+fill -6 64 -235 6 64 -235 minecraft:polished_andesite
+fill -6 64 -231 6 64 -231 minecraft:polished_andesite
+fill -6 64 -227 6 64 -227 minecraft:polished_andesite
+fill -6 64 -223 6 64 -223 minecraft:polished_andesite
+fill -6 64 -219 6 64 -219 minecraft:polished_andesite
+fill -6 64 -215 6 64 -215 minecraft:polished_andesite
+fill -6 64 -211 6 64 -211 minecraft:polished_andesite
+fill -6 64 -207 6 64 -207 minecraft:polished_andesite
+fill -6 64 -203 6 64 -203 minecraft:polished_andesite
+fill -6 64 -199 6 64 -199 minecraft:polished_andesite
+fill -6 64 -195 6 64 -195 minecraft:polished_andesite
+fill -6 64 -191 6 64 -191 minecraft:polished_andesite
+fill -6 64 -187 6 64 -187 minecraft:polished_andesite
+fill -6 64 -183 6 64 -183 minecraft:polished_andesite
+fill -6 64 -179 6 64 -179 minecraft:polished_andesite
+fill -6 64 -175 6 64 -175 minecraft:polished_andesite
+fill -6 64 -171 6 64 -171 minecraft:polished_andesite
+fill -6 64 -167 6 64 -167 minecraft:polished_andesite
+fill -6 64 -163 6 64 -163 minecraft:polished_andesite
+fill -6 64 -159 6 64 -159 minecraft:polished_andesite
+fill -6 64 -155 6 64 -155 minecraft:polished_andesite
+fill -6 64 -151 6 64 -151 minecraft:polished_andesite
+fill -6 64 -147 6 64 -147 minecraft:polished_andesite
+fill -6 64 -143 6 64 -143 minecraft:polished_andesite
+fill -6 64 -139 6 64 -139 minecraft:polished_andesite
+fill -6 64 -135 6 64 -135 minecraft:polished_andesite
+fill -6 64 -131 6 64 -131 minecraft:polished_andesite
+fill -6 64 -127 6 64 -127 minecraft:polished_andesite
+fill -6 64 -123 6 64 -123 minecraft:polished_andesite
+fill -6 64 -119 6 64 -119 minecraft:polished_andesite
+fill -6 64 -115 6 64 -115 minecraft:polished_andesite
+fill -6 64 -111 6 64 -111 minecraft:polished_andesite
+fill -6 64 -107 6 64 -107 minecraft:polished_andesite
+fill -6 64 -103 6 64 -103 minecraft:polished_andesite
+
+# --- Hot-Topical CORRIDOR section (x=-6..6, z=-186..-200): eggplant floor transition ---
+fill -5 64 -200 5 64 -186 minecraft:purple_concrete
+
+# --- Store wall lower accents (baseboard level y=65-66) ---
+# Hot-Topical west store: black concrete lower walls + crimson trim
+fill -49 65 -200 -49 66 -186 minecraft:black_concrete
+fill -49 65 -186 -7 66 -186 minecraft:black_concrete
+fill -49 65 -200 -7 66 -200 minecraft:black_concrete
+fill -7 65 -200 -7 66 -186 minecraft:black_concrete
+# Purple terracotta accent (lower 2-block band inside Hot-Topical)
+fill -48 65 -199 -8 66 -187 minecraft:purple_terracotta
+
+# Build-A-Boss west store: light blue concrete walls
+fill -49 65 -215 -49 66 -201 minecraft:light_blue_concrete
+fill -49 65 -201 -7 66 -201 minecraft:light_blue_concrete
+fill -49 65 -215 -7 66 -215 minecraft:light_blue_concrete
+fill -7 65 -215 -7 66 -201 minecraft:light_blue_concrete
+
+# GameStomp west store: dark oak planks lower walls
+fill -49 65 -245 -49 66 -231 minecraft:dark_oak_planks
+fill -49 65 -231 -7 66 -231 minecraft:dark_oak_planks
+fill -49 65 -245 -7 66 -245 minecraft:dark_oak_planks
+fill -7 65 -245 -7 66 -231 minecraft:dark_oak_planks
+
+# Cluck-O-Mart west store: red concrete lower walls
+fill -49 65 -260 -49 66 -246 minecraft:red_concrete
+fill -49 65 -246 -7 66 -246 minecraft:red_concrete
+fill -49 65 -260 -7 66 -260 minecraft:red_concrete
+fill -7 65 -260 -7 66 -246 minecraft:red_concrete

--- a/output/motfb-datapack/data/motfb/function/build/f2_lighting.mcfunction
+++ b/output/motfb-datapack/data/motfb/function/build/f2_lighting.mcfunction
@@ -1,0 +1,128 @@
+# =============================================================================
+# F2 — Interior Lighting Rework (MIN-160)
+# Removes Jason's sea-lantern stop-gap (~34,600 blocks at y=79 and y=96)
+# and replaces with intentional period-appropriate recessed troffer lighting.
+#
+# Floor 1 ceiling (y=79): white concrete base with sea lanterns every 4 z blocks
+# — reads as long-run fluorescent troffers running east-west per mall aesthetic.
+# Floor 2 mezzanine (y=96): same pattern, sparser.
+# Per-store ceiling overrides follow the base pass.
+# =============================================================================
+
+# --- Floor 1: clear stop-gap sea lanterns at y=78 and y=79 ---
+fill -49 79 -279 49 79 -101 minecraft:white_concrete replace minecraft:sea_lantern
+fill -49 78 -279 49 78 -101 minecraft:white_concrete replace minecraft:sea_lantern
+
+# --- Floor 1: corridor ceiling grid (smooth_stone_slab as drop-ceiling tiles) ---
+# Central corridor x=-6..6: smooth stone slab grid with sea lantern troffers
+fill -6 79 -279 6 79 -101 minecraft:smooth_stone_slab[type=top]
+
+# --- Floor 1: troffer strip rows every 4 z blocks in the full interior ---
+# These replace the slab grid back to sea_lantern at the row positions,
+# giving a strip-of-troffers look (each strip is 1 block wide, full mall width)
+fill -49 79 -279 49 79 -279 minecraft:sea_lantern
+fill -49 79 -275 49 79 -275 minecraft:sea_lantern
+fill -49 79 -271 49 79 -271 minecraft:sea_lantern
+fill -49 79 -267 49 79 -267 minecraft:sea_lantern
+fill -49 79 -263 49 79 -263 minecraft:sea_lantern
+fill -49 79 -259 49 79 -259 minecraft:sea_lantern
+fill -49 79 -255 49 79 -255 minecraft:sea_lantern
+fill -49 79 -251 49 79 -251 minecraft:sea_lantern
+fill -49 79 -247 49 79 -247 minecraft:sea_lantern
+fill -49 79 -243 49 79 -243 minecraft:sea_lantern
+fill -49 79 -239 49 79 -239 minecraft:sea_lantern
+fill -49 79 -235 49 79 -235 minecraft:sea_lantern
+fill -49 79 -231 49 79 -231 minecraft:sea_lantern
+fill -49 79 -227 49 79 -227 minecraft:sea_lantern
+fill -49 79 -223 49 79 -223 minecraft:sea_lantern
+fill -49 79 -219 49 79 -219 minecraft:sea_lantern
+fill -49 79 -215 49 79 -215 minecraft:sea_lantern
+fill -49 79 -211 49 79 -211 minecraft:sea_lantern
+fill -49 79 -207 49 79 -207 minecraft:sea_lantern
+fill -49 79 -203 49 79 -203 minecraft:sea_lantern
+fill -49 79 -199 49 79 -199 minecraft:sea_lantern
+fill -49 79 -195 49 79 -195 minecraft:sea_lantern
+fill -49 79 -191 49 79 -191 minecraft:sea_lantern
+fill -49 79 -187 49 79 -187 minecraft:sea_lantern
+fill -49 79 -183 49 79 -183 minecraft:sea_lantern
+fill -49 79 -179 49 79 -179 minecraft:sea_lantern
+fill -49 79 -175 49 79 -175 minecraft:sea_lantern
+fill -49 79 -171 49 79 -171 minecraft:sea_lantern
+fill -49 79 -167 49 79 -167 minecraft:sea_lantern
+fill -49 79 -163 49 79 -163 minecraft:sea_lantern
+fill -49 79 -159 49 79 -159 minecraft:sea_lantern
+fill -49 79 -155 49 79 -155 minecraft:sea_lantern
+fill -49 79 -151 49 79 -151 minecraft:sea_lantern
+fill -49 79 -147 49 79 -147 minecraft:sea_lantern
+fill -49 79 -143 49 79 -143 minecraft:sea_lantern
+fill -49 79 -139 49 79 -139 minecraft:sea_lantern
+fill -49 79 -135 49 79 -135 minecraft:sea_lantern
+fill -49 79 -131 49 79 -131 minecraft:sea_lantern
+fill -49 79 -127 49 79 -127 minecraft:sea_lantern
+fill -49 79 -123 49 79 -123 minecraft:sea_lantern
+fill -49 79 -119 49 79 -119 minecraft:sea_lantern
+fill -49 79 -115 49 79 -115 minecraft:sea_lantern
+fill -49 79 -111 49 79 -111 minecraft:sea_lantern
+fill -49 79 -107 49 79 -107 minecraft:sea_lantern
+fill -49 79 -103 49 79 -103 minecraft:sea_lantern
+
+# --- Per-store ceiling overrides (F1 ceiling level y=79) ---
+
+# GameStomp (west, z=-231..-245): intentionally no overhead ambient per §1.4
+# Only motivated light sources in the store — remove troffers from the store interior
+fill -49 79 -245 -7 79 -231 minecraft:blackstone replace minecraft:sea_lantern
+fill -49 79 -245 -7 79 -231 minecraft:blackstone replace minecraft:white_concrete
+fill -49 79 -245 -7 79 -231 minecraft:blackstone replace minecraft:smooth_stone_slab
+
+# Hot-Topical (west, z=-186..-200): soul lanterns only per §1.5
+fill -49 79 -200 -7 79 -186 minecraft:soul_lantern replace minecraft:sea_lantern
+fill -49 79 -200 -7 79 -186 minecraft:black_concrete replace minecraft:white_concrete
+fill -49 79 -200 -7 79 -186 minecraft:black_concrete replace minecraft:smooth_stone_slab
+
+# Spencer's Cursed Gifts (east, z=-246..-260): redstone lamps per §1.6
+fill 7 79 -260 49 79 -246 minecraft:redstone_lamp replace minecraft:sea_lantern
+fill 7 79 -260 49 79 -246 minecraft:yellow_concrete replace minecraft:white_concrete
+
+# Bath & Bodywork Sanctum (east, z=-231..-245): end rods flush per §1.7
+fill 7 79 -245 49 79 -231 minecraft:end_rod[facing=down] replace minecraft:sea_lantern
+fill 7 79 -245 49 79 -231 minecraft:white_concrete replace minecraft:smooth_stone_slab
+
+# --- Floor 2 mezzanine ceiling (y=96): clear stop-gap sea lanterns ---
+fill -49 96 -279 49 96 -101 minecraft:white_concrete replace minecraft:sea_lantern
+fill -49 95 -279 49 95 -101 minecraft:white_concrete replace minecraft:sea_lantern
+
+# Floor 2: iron lanterns on posts and wall sconces (use sea_lantern sparser grid)
+# Strip troffers every 6 blocks (mezzanine gets dimmer lighting per spec §3.2)
+fill -49 96 -279 49 96 -279 minecraft:sea_lantern
+fill -49 96 -273 49 96 -273 minecraft:sea_lantern
+fill -49 96 -267 49 96 -267 minecraft:sea_lantern
+fill -49 96 -261 49 96 -261 minecraft:sea_lantern
+fill -49 96 -255 49 96 -255 minecraft:sea_lantern
+fill -49 96 -249 49 96 -249 minecraft:sea_lantern
+fill -49 96 -243 49 96 -243 minecraft:sea_lantern
+fill -49 96 -237 49 96 -237 minecraft:sea_lantern
+fill -49 96 -231 49 96 -231 minecraft:sea_lantern
+fill -49 96 -225 49 96 -225 minecraft:sea_lantern
+fill -49 96 -219 49 96 -219 minecraft:sea_lantern
+fill -49 96 -213 49 96 -213 minecraft:sea_lantern
+fill -49 96 -207 49 96 -207 minecraft:sea_lantern
+fill -49 96 -201 49 96 -201 minecraft:sea_lantern
+fill -49 96 -195 49 96 -195 minecraft:sea_lantern
+fill -49 96 -189 49 96 -189 minecraft:sea_lantern
+fill -49 96 -183 49 96 -183 minecraft:sea_lantern
+fill -49 96 -177 49 96 -177 minecraft:sea_lantern
+fill -49 96 -171 49 96 -171 minecraft:sea_lantern
+fill -49 96 -165 49 96 -165 minecraft:sea_lantern
+fill -49 96 -159 49 96 -159 minecraft:sea_lantern
+fill -49 96 -153 49 96 -153 minecraft:sea_lantern
+fill -49 96 -147 49 96 -147 minecraft:sea_lantern
+fill -49 96 -141 49 96 -141 minecraft:sea_lantern
+fill -49 96 -135 49 96 -135 minecraft:sea_lantern
+fill -49 96 -129 49 96 -129 minecraft:sea_lantern
+fill -49 96 -123 49 96 -123 minecraft:sea_lantern
+fill -49 96 -117 49 96 -117 minecraft:sea_lantern
+fill -49 96 -111 49 96 -111 minecraft:sea_lantern
+fill -49 96 -105 49 96 -105 minecraft:sea_lantern
+
+# --- Reset difficulty if Jason had overridden it ---
+difficulty normal

--- a/output/motfb-datapack/data/motfb/function/build/f3_office.mcfunction
+++ b/output/motfb-datapack/data/motfb/function/build/f3_office.mcfunction
@@ -1,0 +1,86 @@
+# =============================================================================
+# F3 — Office Floor Ceiling Fix (MIN-160)
+# Jason's walkthrough found that the office roof cap (claimed in commit as
+# "Roof y=113-115: flat quartz cap") was not at the expected coordinates or
+# was absent. This function fills the cap and verifies internal ceiling.
+#
+# Office footprint derived from reset.mcfunction backup clone:
+#   x=-12..12, z=-220..-200
+#   Floor blocks at y=97 (walkable y=98)
+#   Interior space to y=111
+#   Roof cap: y=112-115 (smooth quartz flat top, matching mall exterior)
+#
+# Using fill ... replace air so we don't overwrite existing solid geometry.
+# =============================================================================
+
+# --- Roof cap: solid smooth quartz over the office footprint ---
+fill -12 113 -220 12 113 -200 minecraft:smooth_quartz
+fill -12 114 -220 12 114 -200 minecraft:smooth_quartz
+fill -12 115 -220 12 115 -200 minecraft:smooth_quartz
+
+# --- Interior ceiling at y=111 (top of office space): white concrete ---
+fill -12 111 -220 12 111 -200 minecraft:white_concrete
+
+# --- Sea lanterns recessed into office ceiling per §1.11 (Phase 1 state) ---
+# Sea lanterns behind smooth stone slab grid at y=111
+# These are the Phase 1 "surgically bright" lights — every 2 blocks
+fill -12 111 -220 12 111 -200 minecraft:smooth_stone_slab[type=top] replace minecraft:white_concrete
+fill -10 111 -218 10 111 -202 minecraft:sea_lantern replace minecraft:smooth_stone_slab
+# Restore the outer slab ring (border stays slab, inner area alternates)
+fill -12 111 -220 12 111 -220 minecraft:smooth_stone_slab[type=top] replace minecraft:sea_lantern
+fill -12 111 -200 12 111 -200 minecraft:smooth_stone_slab[type=top] replace minecraft:sea_lantern
+fill -12 111 -220 -12 111 -200 minecraft:smooth_stone_slab[type=top] replace minecraft:sea_lantern
+fill 12 111 -220 12 111 -200 minecraft:smooth_stone_slab[type=top] replace minecraft:sea_lantern
+
+# --- Office floor (y=97): light gray carpet per §1.11 ---
+fill -11 97 -219 11 97 -201 minecraft:light_gray_carpet
+
+# --- Office walls: smooth quartz with light gray concrete and dark oak trim ---
+# Already built in rough pass; just ensure the exterior-facing roof cap is solid
+# north wall cap above office
+fill -12 112 -220 12 112 -220 minecraft:smooth_quartz
+# south wall cap
+fill -12 112 -200 12 112 -200 minecraft:smooth_quartz
+# east wall cap
+fill 12 112 -220 12 112 -200 minecraft:smooth_quartz
+# west wall cap
+fill -12 112 -220 -12 112 -200 minecraft:smooth_quartz
+
+# --- Side walls of office: dark oak trim at ceiling level per §1.11 ---
+fill -11 110 -219 11 110 -219 minecraft:dark_oak_planks replace minecraft:air
+fill -11 110 -201 11 110 -201 minecraft:dark_oak_planks replace minecraft:air
+fill -11 110 -219 -11 110 -201 minecraft:dark_oak_planks replace minecraft:air
+fill 11 110 -219 11 110 -201 minecraft:dark_oak_planks replace minecraft:air
+
+# --- Signing Lectern raised platform (§6.5) ---
+# 1-block smooth quartz pad, lectern facing south (toward door)
+setblock 0 98 -213 minecraft:smooth_quartz
+setblock 0 99 -213 minecraft:lectern[facing=south]
+setblock 0 99 -214 minecraft:end_rod[facing=north]
+
+# --- Tearing Pad (§6.6): redstone block + pressure plate ---
+setblock 0 98 -207 minecraft:redstone_block
+setblock 0 99 -207 minecraft:oak_pressure_plate
+# Magenta stained glass ring in floor around pad
+setblock 1 98 -207 minecraft:magenta_stained_glass
+setblock -1 98 -207 minecraft:magenta_stained_glass
+setblock 0 98 -208 minecraft:magenta_stained_glass
+setblock 0 98 -206 minecraft:magenta_stained_glass
+
+# --- Gold stained glass ring around Signing Lectern ---
+setblock 1 98 -213 minecraft:gold_block
+setblock -1 98 -213 minecraft:gold_block
+setblock 0 98 -214 minecraft:gold_block
+setblock 0 98 -212 minecraft:gold_block
+
+# --- Polished diorite behind desk area (§1.11) ---
+fill -3 97 -212 3 97 -207 minecraft:polished_diorite
+fill -11 97 -219 -4 97 -201 minecraft:polished_diorite
+
+# --- Desk: dark oak planks + chiseled bookshelf (§1.11) ---
+fill -2 98 -211 2 100 -209 minecraft:dark_oak_planks replace minecraft:air
+setblock -2 100 -210 minecraft:chiseled_bookshelf
+
+# --- Redstone lamp on desk (always-powered, Phase 2 sole light source §3.3) ---
+setblock 0 101 -210 minecraft:redstone_lamp
+setblock 0 101 -211 minecraft:redstone_block

--- a/output/motfb-datapack/data/motfb/function/build/scene_design.mcfunction
+++ b/output/motfb-datapack/data/motfb/function/build/scene_design.mcfunction
@@ -1,0 +1,20 @@
+# =============================================================================
+# MOTFB Scene Design Pass — Phase D-rev-1b (MIN-163)
+# Scene Designer supplemental build on top of MIN-160 Game Dev foundation.
+#
+# What this adds:
+#   scene_dome     — Fountain plaza glass dome atrium (§3.3 Setpiece 1)
+#   scene_power    — Spencer's redstone lamps powered + color-shift glass
+#   scene_details  — Store entry end rods, corridor columns, wall baseboards
+#
+# Run AFTER visual_rev1 (MIN-160 foundation must be applied first).
+# Usage: function motfb:build/scene_design
+# =============================================================================
+
+tellraw @a {"text":"[MOTFB] Applying Scene Designer pass (MIN-163)...","color":"light_purple","italic":true}
+
+function motfb:build/scene_dome
+function motfb:build/scene_power
+function motfb:build/scene_details
+
+tellraw @a {"text":"[MOTFB] Scene design pass complete. Run /save-all before zipping.","color":"green","bold":true}

--- a/output/motfb-datapack/data/motfb/function/build/scene_details.mcfunction
+++ b/output/motfb-datapack/data/motfb/function/build/scene_details.mcfunction
@@ -1,0 +1,182 @@
+# =============================================================================
+# SCENE DESIGN: Store Entry Details + Corridor Polish (MIN-163)
+# §1.0 — "End rods on dark oak brackets at each store entry transition"
+# §1.0 — Structural columns: smooth quartz pillar + iron bars bracket
+# §1.0 — Wall: smooth stone lower baseboard + light gray concrete upper stripe
+#
+# Store entry z-boundaries (west side x=-7, east side x=7):
+#   Hot-Topical W:      z=-186 and z=-200
+#   Build-A-Boss W:     z=-201 and z=-215
+#   Cinnabog W:         z=-216 and z=-230
+#   GameStomp W:        z=-231 and z=-245
+#   Cluck-O-Mart W:     z=-246 and z=-260
+#   Spencer's E:        z=-246 and z=-260
+#   Bath & Body E:      z=-231 and z=-245
+#   Pretzel E:          z=-216 and z=-230
+#   Spunky's E:         z=-201 and z=-215
+# SEARZ entry (full width): z=-261
+# =============================================================================
+
+# =============================================================================
+# END RODS AT STORE ENTRIES — dark oak bracket + end rod facing outward
+# Placed at y=76 (top of entry arch, visible from corridor)
+# West side (x=-7): end rod facing west  East side (x=7): end rod facing east
+# =============================================================================
+
+# West side store entries
+setblock -6 76 -186 minecraft:dark_oak_planks
+setblock -7 76 -186 minecraft:end_rod[facing=west]
+setblock -6 76 -201 minecraft:dark_oak_planks
+setblock -7 76 -201 minecraft:end_rod[facing=west]
+setblock -6 76 -216 minecraft:dark_oak_planks
+setblock -7 76 -216 minecraft:end_rod[facing=west]
+setblock -6 76 -231 minecraft:dark_oak_planks
+setblock -7 76 -231 minecraft:end_rod[facing=west]
+setblock -6 76 -246 minecraft:dark_oak_planks
+setblock -7 76 -246 minecraft:end_rod[facing=west]
+setblock -6 76 -260 minecraft:dark_oak_planks
+setblock -7 76 -260 minecraft:end_rod[facing=west]
+setblock -6 76 -200 minecraft:dark_oak_planks
+setblock -7 76 -200 minecraft:end_rod[facing=west]
+setblock -6 76 -215 minecraft:dark_oak_planks
+setblock -7 76 -215 minecraft:end_rod[facing=west]
+setblock -6 76 -230 minecraft:dark_oak_planks
+setblock -7 76 -230 minecraft:end_rod[facing=west]
+setblock -6 76 -245 minecraft:dark_oak_planks
+setblock -7 76 -245 minecraft:end_rod[facing=west]
+
+# East side store entries
+setblock 6 76 -186 minecraft:dark_oak_planks
+setblock 7 76 -186 minecraft:end_rod[facing=east]
+setblock 6 76 -201 minecraft:dark_oak_planks
+setblock 7 76 -201 minecraft:end_rod[facing=east]
+setblock 6 76 -216 minecraft:dark_oak_planks
+setblock 7 76 -216 minecraft:end_rod[facing=east]
+setblock 6 76 -231 minecraft:dark_oak_planks
+setblock 7 76 -231 minecraft:end_rod[facing=east]
+setblock 6 76 -246 minecraft:dark_oak_planks
+setblock 7 76 -246 minecraft:end_rod[facing=east]
+setblock 6 76 -260 minecraft:dark_oak_planks
+setblock 7 76 -260 minecraft:end_rod[facing=east]
+setblock 6 76 -200 minecraft:dark_oak_planks
+setblock 7 76 -200 minecraft:end_rod[facing=east]
+setblock 6 76 -215 minecraft:dark_oak_planks
+setblock 7 76 -215 minecraft:end_rod[facing=east]
+setblock 6 76 -230 minecraft:dark_oak_planks
+setblock 7 76 -230 minecraft:end_rod[facing=east]
+setblock 6 76 -245 minecraft:dark_oak_planks
+setblock 7 76 -245 minecraft:end_rod[facing=east]
+
+# SEARZ grand entry (full width, z=-261)
+setblock -6 76 -261 minecraft:dark_oak_planks
+setblock -7 76 -261 minecraft:end_rod[facing=west]
+setblock 6 76 -261 minecraft:dark_oak_planks
+setblock 7 76 -261 minecraft:end_rod[facing=east]
+
+# =============================================================================
+# STRUCTURAL COLUMNS — smooth quartz pillar at corridor widths
+# Placed at x=±5, y=65..71 (half-height decorative columns against the walls)
+# at the midpoint z of each store bay (between entry z boundaries)
+# =============================================================================
+
+# Hot-Topical midpoint z=-193 — but Hot-Topical has purple terracotta walls; skip
+# (hot-topical already has a distinct look; columns would clash)
+
+# Build-A-Boss corridor midpoint z=-208
+setblock -5 65 -208 minecraft:quartz_pillar[axis=y]
+setblock -5 66 -208 minecraft:quartz_pillar[axis=y]
+setblock -5 67 -208 minecraft:quartz_pillar[axis=y]
+setblock -5 68 -208 minecraft:quartz_pillar[axis=y]
+setblock -5 69 -208 minecraft:iron_bars
+setblock 5 65 -208 minecraft:quartz_pillar[axis=y]
+setblock 5 66 -208 minecraft:quartz_pillar[axis=y]
+setblock 5 67 -208 minecraft:quartz_pillar[axis=y]
+setblock 5 68 -208 minecraft:quartz_pillar[axis=y]
+setblock 5 69 -208 minecraft:iron_bars
+
+# Cinnabog midpoint z=-223
+setblock -5 65 -223 minecraft:quartz_pillar[axis=y]
+setblock -5 66 -223 minecraft:quartz_pillar[axis=y]
+setblock -5 67 -223 minecraft:quartz_pillar[axis=y]
+setblock -5 68 -223 minecraft:quartz_pillar[axis=y]
+setblock -5 69 -223 minecraft:iron_bars
+setblock 5 65 -223 minecraft:quartz_pillar[axis=y]
+setblock 5 66 -223 minecraft:quartz_pillar[axis=y]
+setblock 5 67 -223 minecraft:quartz_pillar[axis=y]
+setblock 5 68 -223 minecraft:quartz_pillar[axis=y]
+setblock 5 69 -223 minecraft:iron_bars
+
+# GameStomp / Spencer's midpoint z=-238
+setblock -5 65 -238 minecraft:quartz_pillar[axis=y]
+setblock -5 66 -238 minecraft:quartz_pillar[axis=y]
+setblock -5 67 -238 minecraft:quartz_pillar[axis=y]
+setblock -5 68 -238 minecraft:quartz_pillar[axis=y]
+setblock -5 69 -238 minecraft:iron_bars
+setblock 5 65 -238 minecraft:quartz_pillar[axis=y]
+setblock 5 66 -238 minecraft:quartz_pillar[axis=y]
+setblock 5 67 -238 minecraft:quartz_pillar[axis=y]
+setblock 5 68 -238 minecraft:quartz_pillar[axis=y]
+setblock 5 69 -238 minecraft:iron_bars
+
+# Cluck-O-Mart / Bath & Body midpoint z=-253
+setblock -5 65 -253 minecraft:quartz_pillar[axis=y]
+setblock -5 66 -253 minecraft:quartz_pillar[axis=y]
+setblock -5 67 -253 minecraft:quartz_pillar[axis=y]
+setblock -5 68 -253 minecraft:quartz_pillar[axis=y]
+setblock -5 69 -253 minecraft:iron_bars
+setblock 5 65 -253 minecraft:quartz_pillar[axis=y]
+setblock 5 66 -253 minecraft:quartz_pillar[axis=y]
+setblock 5 67 -253 minecraft:quartz_pillar[axis=y]
+setblock 5 68 -253 minecraft:quartz_pillar[axis=y]
+setblock 5 69 -253 minecraft:iron_bars
+
+# Food court / lobby column positions (south of store zone)
+setblock -5 65 -175 minecraft:quartz_pillar[axis=y]
+setblock -5 66 -175 minecraft:quartz_pillar[axis=y]
+setblock -5 67 -175 minecraft:quartz_pillar[axis=y]
+setblock -5 68 -175 minecraft:quartz_pillar[axis=y]
+setblock -5 69 -175 minecraft:iron_bars
+setblock 5 65 -175 minecraft:quartz_pillar[axis=y]
+setblock 5 66 -175 minecraft:quartz_pillar[axis=y]
+setblock 5 67 -175 minecraft:quartz_pillar[axis=y]
+setblock 5 68 -175 minecraft:quartz_pillar[axis=y]
+setblock 5 69 -175 minecraft:iron_bars
+
+# =============================================================================
+# CORRIDOR WALL BASEBOARD — smooth stone lower 2 blocks (y=65-66)
+# Only in the central corridor spine (x=-6..6) not overwriting store walls
+# Uses replace air so we only add to existing gaps, not overwrite store blocks
+# §1.0: "smooth stone (lower 2 blocks, baseboard)"
+# =============================================================================
+
+# West corridor wall baseboard (x=-6 face, y=65-66 on the corridor side)
+fill -6 65 -185 -6 66 -115 minecraft:smooth_stone replace minecraft:air
+# East corridor wall baseboard
+fill 6 65 -185 6 66 -115 minecraft:smooth_stone replace minecraft:air
+
+# =============================================================================
+# CORRIDOR CEILING UPPER STRIPE — light gray concrete near ceiling
+# §1.0: "light gray concrete (upper stripe near ceiling)"
+# Add at y=78 (1 block below the troffer ceiling at y=79) on the corridor walls
+# =============================================================================
+
+fill -6 78 -279 -6 78 -186 minecraft:light_gray_concrete replace minecraft:air
+fill 6 78 -279 6 78 -186 minecraft:light_gray_concrete replace minecraft:air
+
+# =============================================================================
+# FOOD COURT ENTRY ARCH — visual transition from lobby to food court
+# Marks the food court zone entry at z=-126 with an orange concrete arch
+# =============================================================================
+
+setblock -5 65 -126 minecraft:orange_concrete
+setblock -5 66 -126 minecraft:orange_concrete
+setblock -5 67 -126 minecraft:orange_concrete
+setblock -5 68 -126 minecraft:orange_concrete
+setblock 5 65 -126 minecraft:orange_concrete
+setblock 5 66 -126 minecraft:orange_concrete
+setblock 5 67 -126 minecraft:orange_concrete
+setblock 5 68 -126 minecraft:orange_concrete
+fill -4 70 -126 4 70 -126 minecraft:orange_concrete
+fill -3 69 -126 3 69 -126 minecraft:yellow_concrete
+
+tellraw @a {"text":"[MOTFB] Store entry end rods, corridor columns, and wall baseboards added.","color":"green"}

--- a/output/motfb-datapack/data/motfb/function/build/scene_dome.mcfunction
+++ b/output/motfb-datapack/data/motfb/function/build/scene_dome.mcfunction
@@ -1,0 +1,52 @@
+# =============================================================================
+# SCENE DESIGN: Fountain Plaza Glass Dome Atrium (MIN-163)
+# §3.3 Setpiece 1 — "the lungs of the map"
+#
+# Fountain center: x=0, z=-162 (water pool at x=-1..1, z=-161..-163, y=64)
+# Dome footprint: 20×20 = x=-10..10, z=-172..-152
+# Dome top: y=88 (24 blocks above fountain base y=64)
+#
+# Approach: clear the troffer grid (sea_lantern, smooth_stone_slab) from the
+# 20×20 fountain zone at y=79 so the space reads as an open 24-block atrium,
+# then place the concentric glass-ring ceiling at y=88.
+# Uses replace filters only — will not disturb structural wall blocks.
+# =============================================================================
+
+# --- Clear the troffer ceiling from the fountain plaza zone ---
+# Remove sea lantern strips and smooth_stone_slab drop ceiling (both placed by f2_lighting)
+# leave white_concrete and other structural blocks intact
+fill -10 79 -172 10 79 -152 minecraft:air replace minecraft:sea_lantern
+fill -10 79 -172 10 79 -152 minecraft:air replace minecraft:smooth_stone_slab
+
+# --- Glass dome ceiling at y=88 — concentric ring pattern (§3.3) ---
+# Outer band: orange stained glass (amber substitute — "last light of 8:47 PM sun")
+fill -10 88 -172 10 88 -152 minecraft:orange_stained_glass
+# Middle band: cyan stained glass (teal substitute)
+fill -8 88 -170 8 88 -154 minecraft:cyan_stained_glass
+# Inner band: light blue stained glass
+fill -6 88 -168 6 88 -156 minecraft:light_blue_stained_glass
+# Center: clear glass (lets sky through directly above fountain)
+fill -4 88 -166 4 88 -158 minecraft:glass
+
+# --- Slight dome curve: outer ring one block lower (y=87) for visual depth ---
+# Perimeter strip of orange at y=87 (1-block border of the 20×20 zone)
+fill -10 87 -172 10 87 -172 minecraft:orange_stained_glass
+fill -10 87 -152 10 87 -152 minecraft:orange_stained_glass
+fill -10 87 -172 -10 87 -152 minecraft:orange_stained_glass
+fill 10 87 -172 10 87 -152 minecraft:orange_stained_glass
+
+# --- Vertical atrium glass on the dome perimeter (y=80..86) ---
+# These give the atrium volume visible from the plaza floor looking up
+# North wall glass strip (at z=-172, the north edge)
+fill -9 80 -172 9 86 -172 minecraft:glass_pane
+# South wall glass strip (at z=-152, the south edge)
+fill -9 80 -152 9 86 -152 minecraft:glass_pane
+# West wall glass strip (at x=-10)
+fill -10 80 -171 -10 86 -153 minecraft:glass_pane
+# East wall glass strip (at x=10)
+fill 10 80 -171 10 86 -153 minecraft:glass_pane
+
+# --- Fountain sea lanterns already placed by f1_decor at y=63 ---
+# No changes needed to the fountain pool itself
+
+tellraw @a {"text":"[MOTFB] Setpiece 1: Fountain Plaza glass dome built.","color":"aqua"}

--- a/output/motfb-datapack/data/motfb/function/build/scene_lights.mcfunction
+++ b/output/motfb-datapack/data/motfb/function/build/scene_lights.mcfunction
@@ -1,0 +1,47 @@
+# =============================================================================
+# SCENE LIGHTS — Store colored light zones (MIN-163 Phase D-rev-1.5)
+# §3.2 Colored Light Placement — per-store motivated lighting on top of F2 base.
+# Run AFTER f2_lighting.
+# =============================================================================
+
+# --- GameStomp: lime arcade-wall glow (§1.4 §3.2) ---
+# Sea lanterns embedded in back wall face (x=-48), lime stained glass in front (x=-47)
+# Arcade area: z=-232..-244 depth, x=-35..-49
+fill -48 65 -244 -48 70 -232 minecraft:sea_lantern replace minecraft:air
+fill -47 65 -244 -47 70 -232 minecraft:lime_stained_glass replace minecraft:air
+# Glow item frames simulating arcade screen displays (entity — summon, not setblock)
+# Facing:5 = east; frames sit on back wall (x=-47 glass) and face into the aisle
+summon minecraft:glow_item_frame -46 67 -244 {Facing:5b}
+summon minecraft:glow_item_frame -46 67 -240 {Facing:5b}
+summon minecraft:glow_item_frame -46 67 -236 {Facing:5b}
+summon minecraft:glow_item_frame -46 67 -232 {Facing:5b}
+
+# --- Hot-Topical: arena floor soul lanterns (§1.5) ---
+# "soul lanterns at floor level every 6 blocks" — Vampire Queen arena
+# No ceiling change; ceiling soul lanterns already placed by f2_lighting
+setblock -14 65 -189 minecraft:soul_lantern
+setblock -26 65 -189 minecraft:soul_lantern
+setblock -38 65 -189 minecraft:soul_lantern
+setblock -14 65 -196 minecraft:soul_lantern
+setblock -26 65 -196 minecraft:soul_lantern
+setblock -38 65 -196 minecraft:soul_lantern
+
+# --- Cinnabog: back-area soul lanterns on ceiling chains (§1.3) ---
+# "Soul fire lanterns (teal) tucked in the back display case"
+setblock -40 68 -222 minecraft:soul_lantern
+setblock -44 68 -225 minecraft:soul_lantern
+setblock -36 68 -228 minecraft:soul_lantern
+
+# --- Bath & Bodywork Sanctum: lavender backlit wall panels (§1.7 §3.2) ---
+# Sea lanterns behind north interior wall (z=-244), purple glass pane in front (z=-243)
+# Uses replace-air so floor geometry at y=64-66 is not disturbed
+fill 8 67 -244 48 70 -244 minecraft:sea_lantern replace minecraft:air
+fill 8 67 -243 48 70 -243 minecraft:purple_stained_glass_pane replace minecraft:air
+
+# --- Spunky's Sneakers: product-glow display ledge (§1.9 §3.2) ---
+# Smooth quartz ledge at y=68 along east display wall (x=47), glowstone warm fill under
+# Glowstone used as rough-build stand-in for powered redstone lamps (polish phase wires them)
+fill 47 68 -214 47 68 -202 minecraft:smooth_quartz_slab[type=top] replace minecraft:air
+fill 47 67 -214 47 67 -202 minecraft:glowstone replace minecraft:air
+
+tellraw @a {"text":"[MOTFB] Scene lights: colored zones applied.","color":"gold"}

--- a/output/motfb-datapack/data/motfb/function/build/scene_power.mcfunction
+++ b/output/motfb-datapack/data/motfb/function/build/scene_power.mcfunction
@@ -1,0 +1,39 @@
+# =============================================================================
+# SCENE DESIGN: Redstone Lamp Power Fix + Spencer's Stained Glass (MIN-163)
+#
+# Spencer's Cursed Gifts (east, x=7..49, z=-246..-260):
+# f2_lighting placed redstone_lamp at y=79 but no power source.
+# Fix: place redstone_block at y=80 above the lamp zone (above-ceiling cavity,
+# not visible from inside the store). Block above a lamp powers it in vanilla MC.
+#
+# Also applies magenta stained glass overlay over select lamps per §1.6:
+# "magenta stained glass over select lamps for color-shift"
+# =============================================================================
+
+# --- Power Spencer's redstone lamp ceiling ---
+# Redstone blocks sit in the floor/ceiling cavity at y=80 (above the y=79 lamps)
+# Use replace air so we don't overwrite any structural blocks in this cavity
+fill 8 80 -259 48 80 -247 minecraft:redstone_block replace minecraft:air
+
+# --- Magenta stained glass over select lamps (color-shift effect §1.6) ---
+# Place magenta glass pane on top of every other lamp strip for the color shift
+# The lamps are at y=79; glass pane at y=78 (below the lamp, visible from inside)
+# Actually: place colored glass at y=79 replacing every other air block in the
+# lamp zone interior — creates a dappled warm/magenta effect
+fill 14 79 -258 22 79 -248 minecraft:magenta_stained_glass replace minecraft:air
+fill 30 79 -258 38 79 -248 minecraft:magenta_stained_glass replace minecraft:air
+
+# --- Spencer's weird clearance-bin sea lantern (§1.6 "Sea lanterns inside the clearance bin") ---
+# Add a glowing clearance bin at the back of Spencer's (x=40, z=-252)
+setblock 40 65 -252 minecraft:barrel[facing=up]
+setblock 40 64 -252 minecraft:sea_lantern
+
+# --- Ceiling over Spencer's: orange stained glass panels over redstone lamps (§1.6) ---
+# "orange stained glass (warm tint over lamps)" — place orange glass at y=79
+# in the center spine of Spencer's to warm the light
+fill 20 79 -257 35 79 -249 minecraft:orange_stained_glass replace minecraft:redstone_lamp
+
+# Note: those lamps covered by glass are still powered by the redstone_block above
+# but the orange glass filters the color visible from below
+
+tellraw @a {"text":"[MOTFB] Spencer's lamps powered; color-shift glass applied.","color":"gold"}

--- a/output/motfb-datapack/data/motfb/function/build/visual_rev1.mcfunction
+++ b/output/motfb-datapack/data/motfb/function/build/visual_rev1.mcfunction
@@ -24,8 +24,6 @@ function motfb:build/f1_decor
 # F3 — office ceiling
 function motfb:build/f3_office
 
-# Ensure init settings are clean (difficulty was overridden during diagnosis)
-difficulty normal
 time set 13000
 weather clear 999999
 

--- a/output/motfb-datapack/data/motfb/function/build/visual_rev1.mcfunction
+++ b/output/motfb-datapack/data/motfb/function/build/visual_rev1.mcfunction
@@ -1,0 +1,32 @@
+# =============================================================================
+# MOTFB Phase D-rev-1 — Visual Rework Master Function (MIN-160)
+# Run once against the Times_Square__NYC world to apply all four defect fixes:
+#   F1: 90s mall aesthetic (floors, décor, Hot-Topical, per-store theming)
+#   F2: Interior lighting (sea-lantern stop-gap → period troffer grid)
+#   F3: Office ceiling at y=113-115 (roof cap + interior ceiling)
+#   F9: Kraw store entrance arch (visual pre-spawn state; DANGER lamps in spawn_kraw)
+#
+# Usage: function motfb:build/visual_rev1
+# Expected runtime: ~2-3 server ticks (many fill commands; all valid in one call)
+# =============================================================================
+
+tellraw @a {"text":"[MOTFB] Applying Phase D-rev-1 visual rework...","color":"gold","italic":true}
+
+# F2 first — lighting is the most critical (map was pitch black)
+function motfb:build/f2_lighting
+
+# F1 floors — per-store differentiation
+function motfb:build/f1_floors
+
+# F1 décor — fountain, food court, escalator, kiosks, neon, Hot-Topical, Kraw arch
+function motfb:build/f1_decor
+
+# F3 — office ceiling
+function motfb:build/f3_office
+
+# Ensure init settings are clean (difficulty was overridden during diagnosis)
+difficulty normal
+time set 13000
+weather clear 999999
+
+tellraw @a {"text":"[MOTFB] Phase D-rev-1 visual rework complete. /save-all before zipping.","color":"green","bold":true}

--- a/output/motfb-datapack/data/motfb/function/contract/attack.mcfunction
+++ b/output/motfb-datapack/data/motfb/function/contract/attack.mcfunction
@@ -1,0 +1,3 @@
+execute unless score #party mall.ending matches 0 run return fail
+execute if score #party mall.bryan_phase matches 0 if score #party mall.bryan_hp matches ..98 run scoreboard players set #party mall.ending 2
+execute if score #party mall.ending matches 2 if score #party mall.bryan_phase matches 0 run function motfb:ending/b_voided

--- a/output/motfb-datapack/data/motfb/function/contract/give.mcfunction
+++ b/output/motfb-datapack/data/motfb/function/contract/give.mcfunction
@@ -1,0 +1,5 @@
+execute as @a[distance=..4,tag=!has_contract] at @s run tag @s add has_contract
+execute as @a[distance=..4,tag=!has_contract] at @s run tag @s add in_office
+give @a[tag=has_contract,tag=!gave_contract] minecraft:carrot_on_a_stick[custom_model_data={floats:[1001.0f]},custom_name='{"text":"The Original Contract","color":"dark_purple","italic":false,"bold":true}',lore=['{"text":"PARTY OF THE FIRST PART:","color":"dark_gray","italic":false}','{"text":"  The Architect of All Endings","color":"gray","italic":true}','{"text":"","color":"gray"}','{"text":"Right-click on the Signing Lectern: ACCEPT","color":"gold","italic":false}','{"text":"Strike Bryan with a weapon: VOID","color":"red","italic":false}','{"text":"Use Shears while standing on the Tearing Pad: ANNUL","color":"light_purple","italic":false}','{"text":"  (3 journals required)","color":"light_purple","italic":false}']] 1
+tag @a[tag=has_contract,tag=!gave_contract] add gave_contract
+function motfb:pa/job_offer

--- a/output/motfb-datapack/data/motfb/function/contract/sign.mcfunction
+++ b/output/motfb-datapack/data/motfb/function/contract/sign.mcfunction
@@ -1,0 +1,4 @@
+execute as @s at @s unless block ~ ~-1 ~ minecraft:lectern run return fail
+execute as @s unless score #party mall.ending matches 0 run return fail
+scoreboard players set #party mall.ending 1
+function motfb:ending/a_honored

--- a/output/motfb-datapack/data/motfb/function/contract/tear.mcfunction
+++ b/output/motfb-datapack/data/motfb/function/contract/tear.mcfunction
@@ -1,0 +1,10 @@
+execute as @s at @s unless block ~ ~-1 ~ minecraft:redstone_block run return fail
+execute as @s unless score #party mall.ending matches 0 run return fail
+execute if score #party mall.journals matches ..2 run tellraw @s [{"text":"[PA] ","color":"gray"},{"text":"Now sport, that's not how we do things at Liminal Lakes. You haven't read the fine print.","color":"dark_purple","italic":true}]
+execute if score #party mall.journals matches ..2 run playsound minecraft:block.note_block.didgeridoo ambient @s ~ ~ ~ 1 0.8
+execute if score #party mall.journals matches ..2 run return fail
+scoreboard players set #party mall.ending 3
+clear @s minecraft:carrot_on_a_stick[custom_model_data={floats:[1001.0f]}] 1
+particle minecraft:explosion ~ ~1 ~ 0.3 0.3 0.3 0.05 20
+playsound minecraft:entity.item.break ambient @a
+function motfb:ending/c_annulled

--- a/output/motfb-datapack/data/motfb/function/contract/unlock_office.mcfunction
+++ b/output/motfb-datapack/data/motfb/function/contract/unlock_office.mcfunction
@@ -1,0 +1,10 @@
+execute if score #unlock_fired mall.flag matches 1.. run return fail
+scoreboard players set #unlock_fired mall.flag 1
+fill -1 65 -230 1 79 -228 minecraft:air replace minecraft:bedrock
+function motfb:pa/job_offer
+setblock 0 81 -240 minecraft:redstone_lamp[lit=true]
+setblock 0 84 -237 minecraft:redstone_lamp[lit=true]
+setblock 0 88 -234 minecraft:redstone_lamp[lit=true]
+setblock 0 92 -231 minecraft:redstone_lamp[lit=true]
+setblock 0 96 -228 minecraft:redstone_lamp[lit=true]
+playsound minecraft:block.beacon.activate ambient @a ~ ~ ~ 2 1

--- a/output/motfb-datapack/data/motfb/function/ending/a_honored.mcfunction
+++ b/output/motfb-datapack/data/motfb/function/ending/a_honored.mcfunction
@@ -1,0 +1,6 @@
+title @a times 10 200 30
+title @a subtitle {"text":"\"Welcome aboard, sport. The mall thanks you.\"","color":"dark_purple","italic":true}
+title @a title {"text":"ENDING A — HONORED","color":"gold","bold":true}
+playsound minecraft:block.beacon.activate ambient @a ~ ~ ~ 2 1
+stopsound @a music
+schedule function motfb:ending/credits 200t

--- a/output/motfb-datapack/data/motfb/function/ending/b_bosses_depart.mcfunction
+++ b/output/motfb-datapack/data/motfb/function/ending/b_bosses_depart.mcfunction
@@ -1,0 +1,2 @@
+tellraw @a [{"text":"[PA] ","color":"gray","italic":true},{"text":"All departments — your mall manager has been defeated. You are dismissed. Thank you for your service.","color":"dark_purple","italic":true}]
+playsound minecraft:entity.elder_guardian.death ambient @a ~ ~ ~ 2 0.6

--- a/output/motfb-datapack/data/motfb/function/ending/b_voided.mcfunction
+++ b/output/motfb-datapack/data/motfb/function/ending/b_voided.mcfunction
@@ -1,0 +1,12 @@
+scoreboard players set #party mall.bryan_phase 1
+data merge entity @e[tag=motfb_bryan,limit=1] {Invulnerable:0b,NoAI:0b}
+bossbar add motfb:bryan {"text":"Bryan — Mall Manager","color":"dark_purple"}
+bossbar set motfb:bryan players @a[tag=in_office]
+bossbar set motfb:bryan max 99
+bossbar set motfb:bryan value 99
+bossbar set motfb:bryan color purple
+bossbar set motfb:bryan style notched_6
+title @a times 10 60 20
+title @a subtitle {"text":"\"This is really disappointing, sport.\"","color":"dark_purple","italic":true}
+title @a title {"text":"ENDING B — THE VOID CONTRACT","color":"red","bold":true}
+playsound minecraft:entity.wither.spawn hostile @a ~ ~ ~ 2 0.8

--- a/output/motfb-datapack/data/motfb/function/ending/b_voided_finalize.mcfunction
+++ b/output/motfb-datapack/data/motfb/function/ending/b_voided_finalize.mcfunction
@@ -1,0 +1,1 @@
+execute unless score #party mall.bryan_phase matches 3 run function motfb:bryan/phase_3

--- a/output/motfb-datapack/data/motfb/function/ending/c_annulled.mcfunction
+++ b/output/motfb-datapack/data/motfb/function/ending/c_annulled.mcfunction
@@ -1,0 +1,10 @@
+data merge entity @e[tag=motfb_bryan,limit=1] {NoAI:1b}
+stopsound @a music
+title @a times 10 200 30
+title @a subtitle {"text":"\"...thank you, champ.\"","color":"dark_purple","italic":true}
+title @a title {"text":"ENDING C — THE CONTRACT IS TORN","color":"gold","bold":true}
+playsound minecraft:block.note_block.harp ambient @a ~ ~ ~ 2 0.5
+schedule function motfb:ending/c_step2 80t
+schedule function motfb:ending/c_step3 240t
+schedule function motfb:ending/c_step4 360t
+schedule function motfb:ending/credits 440t

--- a/output/motfb-datapack/data/motfb/function/ending/c_step2.mcfunction
+++ b/output/motfb-datapack/data/motfb/function/ending/c_step2.mcfunction
@@ -1,0 +1,3 @@
+title @a times 5 80 20
+title @a title {"text":"The mall is folding.","color":"gray","italic":true}
+particle minecraft:smoke 0 70 -200 30 10 30 0.05 200

--- a/output/motfb-datapack/data/motfb/function/ending/c_step3.mcfunction
+++ b/output/motfb-datapack/data/motfb/function/ending/c_step3.mcfunction
@@ -1,0 +1,2 @@
+function motfb:ending/b_bosses_depart
+tellraw @a [{"text":"The Lost Kid: ","color":"yellow","bold":true},{"text":"\"I think... I think I can go home now.\"","color":"white","italic":true}]

--- a/output/motfb-datapack/data/motfb/function/ending/c_step4.mcfunction
+++ b/output/motfb-datapack/data/motfb/function/ending/c_step4.mcfunction
@@ -1,0 +1,3 @@
+kill @e[tag=motfb_bryan]
+particle minecraft:explosion_emitter 0 105 -212 3 3 3 0.1 5
+function motfb:lostkid/wave_goodbye

--- a/output/motfb-datapack/data/motfb/function/ending/credits.mcfunction
+++ b/output/motfb-datapack/data/motfb/function/ending/credits.mcfunction
@@ -1,0 +1,6 @@
+stopsound @a music
+title @a times 20 200 40
+title @a title {"text":"MALL OF THE FINAL BOSSES","color":"gold","bold":true}
+title @a subtitle {"text":"Thanks for shopping with us.","color":"gray","italic":true}
+playsound minecraft:block.note_block.bell ambient @a ~ ~ ~ 1 0.8
+schedule function motfb:ending/credits_2 220t

--- a/output/motfb-datapack/data/motfb/function/ending/credits_2.mcfunction
+++ b/output/motfb-datapack/data/motfb/function/ending/credits_2.mcfunction
@@ -1,0 +1,4 @@
+title @a times 10 160 30
+title @a title {"text":"Bryan's been waiting a long time for this.","color":"dark_purple","italic":true}
+playsound minecraft:block.note_block.bell ambient @a ~ ~ ~ 1 1.0
+schedule function motfb:ending/credits_3 180t

--- a/output/motfb-datapack/data/motfb/function/ending/credits_3.mcfunction
+++ b/output/motfb-datapack/data/motfb/function/ending/credits_3.mcfunction
@@ -1,0 +1,4 @@
+title @a times 10 60 20
+title @a title {"text":"Return to the parking lot?","color":"white"}
+tp @a 0 65 -88
+playsound minecraft:block.note_block.bell ambient @a ~ ~ ~ 1 1.2

--- a/output/motfb-datapack/data/motfb/function/init.mcfunction
+++ b/output/motfb-datapack/data/motfb/function/init.mcfunction
@@ -1,0 +1,45 @@
+# --- gamerules: mall-feel ---
+gamerule keep_inventory true
+gamerule send_command_feedback false
+gamerule immediate_respawn true
+gamerule spawn_mobs false
+gamerule mob_griefing false
+
+# --- daylight/weather control (commands since gamerule names differ per version) ---
+time set 13000
+weather clear 999999
+
+# --- objectives (add idempotently) ---
+scoreboard objectives add mall.coupons dummy {"text":"Boss Coupons","color":"gold"}
+scoreboard objectives add mall.journals dummy {"text":"Journals","color":"light_purple"}
+scoreboard objectives add mall.ending dummy "Ending"
+scoreboard objectives add mall.bryan_phase dummy "Bryan Phase"
+scoreboard objectives add mall.bryan_hp dummy "Bryan HP"
+scoreboard objectives add mall.contract_use minecraft.used:minecraft.carrot_on_a_stick
+scoreboard objectives add mall.shears_use minecraft.used:minecraft.shears
+scoreboard objectives add mall.pa_cooldown dummy
+scoreboard objectives add mall.lk_cooldown dummy
+scoreboard objectives add mall.flag dummy
+scoreboard objectives add mall.deaths deathCount
+
+# --- HUD ---
+scoreboard objectives setdisplay sidebar mall.coupons
+scoreboard objectives setdisplay list mall.journals
+
+# --- teams ---
+team add motfb_boss
+team modify motfb_boss color red
+team modify motfb_boss collisionRule pushOtherTeams
+team add motfb_bryan
+team modify motfb_bryan color dark_purple
+
+# --- fake-player init ---
+execute unless score #party mall.coupons matches 0.. run scoreboard players set #party mall.coupons 0
+execute unless score #party mall.journals matches 0.. run scoreboard players set #party mall.journals 0
+execute unless score #party mall.ending matches 0.. run scoreboard players set #party mall.ending 0
+execute unless score #party mall.bryan_phase matches 0.. run scoreboard players set #party mall.bryan_phase 0
+
+# --- set spawn inside mall entrance ---
+spawnpoint @a 0 65 -150
+
+tellraw @a {"text":"Liminal Lakes Mall — datapack loaded.","color":"dark_gray","italic":true}

--- a/output/motfb-datapack/data/motfb/function/init.mcfunction
+++ b/output/motfb-datapack/data/motfb/function/init.mcfunction
@@ -1,3 +1,6 @@
+# --- difficulty (must be Hard so summoned hostiles persist; Peaceful despawns them) ---
+difficulty hard
+
 # --- gamerules: mall-feel ---
 gamerule keep_inventory true
 gamerule send_command_feedback false

--- a/output/motfb-datapack/data/motfb/function/lostkid/despawn.mcfunction
+++ b/output/motfb-datapack/data/motfb/function/lostkid/despawn.mcfunction
@@ -1,0 +1,1 @@
+kill @e[tag=motfb_lostkid]

--- a/output/motfb-datapack/data/motfb/function/lostkid/follow_tick.mcfunction
+++ b/output/motfb-datapack/data/motfb/function/lostkid/follow_tick.mcfunction
@@ -1,0 +1,5 @@
+execute as @a[tag=lk_following,limit=1] at @s as @e[tag=motfb_lostkid,limit=1] at @s if entity @p[tag=lk_following,distance=8..] run tp @s @p[tag=lk_following,limit=1]
+execute as @a[tag=lk_following] at @s unless entity @s[x=-52,y=60,z=-282,dx=104,dy=60,dz=184] run tag @s remove lk_following
+execute as @a[tag=lk_following] at @s unless entity @s[x=-52,y=60,z=-282,dx=104,dy=60,dz=184] run tellraw @s [{"text":"The Lost Kid: ","color":"yellow","bold":true},{"text":"\"Nah dude, I'm staying. Mall hours forever, lowkey.\"","color":"white","italic":true}]
+execute as @a[tag=lk_following] if score @s mall.lk_cooldown matches ..0 if score #party mall.coupons matches 5..9 run function motfb:lostkid/line_bryan
+execute as @a[tag=lk_following] if score @s mall.lk_cooldown matches ..0 if score #searz_killed mall.flag matches 1 run function motfb:lostkid/line_searz_post

--- a/output/motfb-datapack/data/motfb/function/lostkid/line_arcade.mcfunction
+++ b/output/motfb-datapack/data/motfb/function/lostkid/line_arcade.mcfunction
@@ -1,0 +1,3 @@
+scoreboard players set @s mall.lk_cooldown 600
+tellraw @a [{"text":"The Lost Kid: ","color":"yellow","bold":true},{"text":"\"This place is wild. Like, seriously. My mom said she'd pick me up at three. It's been... I don't know how long it's been.\"","color":"white","italic":true}]
+playsound minecraft:entity.villager.ambient ambient @s

--- a/output/motfb-datapack/data/motfb/function/lostkid/line_bryan.mcfunction
+++ b/output/motfb-datapack/data/motfb/function/lostkid/line_bryan.mcfunction
@@ -1,0 +1,3 @@
+scoreboard players set @s mall.lk_cooldown 800
+tellraw @a [{"text":"The Lost Kid: ","color":"yellow","bold":true},{"text":"\"Hey, I saw the guy upstairs through the window once. He had two coffees and he was talking to both of them. Lowkey don't go up there.\"","color":"white","italic":true}]
+playsound minecraft:entity.villager.ambient ambient @s

--- a/output/motfb-datapack/data/motfb/function/lostkid/line_searz_post.mcfunction
+++ b/output/motfb-datapack/data/motfb/function/lostkid/line_searz_post.mcfunction
@@ -1,0 +1,3 @@
+scoreboard players set @s mall.lk_cooldown 1000
+tellraw @a [{"text":"The Lost Kid: ","color":"yellow","bold":true},{"text":"\"SEARZ had a three-floor store. Three floors! And now it's just... over. That's kind of inspirational actually. Kind of.\"","color":"white","italic":true}]
+playsound minecraft:entity.villager.ambient ambient @s

--- a/output/motfb-datapack/data/motfb/function/lostkid/recruit.mcfunction
+++ b/output/motfb-datapack/data/motfb/function/lostkid/recruit.mcfunction
@@ -1,0 +1,5 @@
+tag @s add lk_following
+clear @s minecraft:bread[custom_name='{"text":"Mall Pretzel","color":"yellow"}'] 1
+tellraw @a [{"text":"The Lost Kid: ","color":"yellow","bold":true},{"text":"\"Sick. You're a real one. Lead the way, lowkey.\"","color":"white","italic":true}]
+playsound minecraft:entity.villager.yes neutral @s
+function motfb:lostkid/line_arcade

--- a/output/motfb-datapack/data/motfb/function/lostkid/spawn_at_arcade.mcfunction
+++ b/output/motfb-datapack/data/motfb/function/lostkid/spawn_at_arcade.mcfunction
@@ -1,0 +1,2 @@
+kill @e[tag=motfb_lostkid]
+summon villager -30 65 -238 {Tags:["motfb_lostkid"],CustomName:'{"text":"The Lost Kid","color":"yellow","italic":false}',CustomNameVisible:1b,VillagerData:{type:"plains",profession:"none",level:1},NoAI:0b,Silent:1b,Invulnerable:1b,PersistenceRequired:1b,Health:20.0f,Attributes:[{Name:"minecraft:movement_speed",Base:0.5},{Name:"minecraft:follow_range",Base:64}]}

--- a/output/motfb-datapack/data/motfb/function/lostkid/wave_goodbye.mcfunction
+++ b/output/motfb-datapack/data/motfb/function/lostkid/wave_goodbye.mcfunction
@@ -1,0 +1,3 @@
+tellraw @a [{"text":"The Lost Kid: ","color":"yellow","bold":true},{"text":"\"Tell my mom I said hi. Also tell her I figured it out. She'll know what that means.\"","color":"white","italic":true}]
+playsound minecraft:entity.villager.yes ambient @a
+schedule function motfb:lostkid/despawn 80t

--- a/output/motfb-datapack/data/motfb/function/pa/code_lavender.mcfunction
+++ b/output/motfb-datapack/data/motfb/function/pa/code_lavender.mcfunction
@@ -1,0 +1,3 @@
+scoreboard players set @s mall.pa_cooldown 2400
+playsound minecraft:block.note_block.bell ambient @s ~ ~ ~ 0.6 1.4
+tellraw @a [{"text":"[PA] ","color":"gray","italic":true},{"text":"Attention shoppers — and shopper — we have a Code Lavender at Build-A-Boss. Janice, please escort the bear back to the workshop. Nobody panic. Bryan loves you. Bryan loves shopping. Have you tried the pretzels?","color":"gold","italic":true}]

--- a/output/motfb-datapack/data/motfb/function/pa/core_hungry.mcfunction
+++ b/output/motfb-datapack/data/motfb/function/pa/core_hungry.mcfunction
@@ -1,0 +1,3 @@
+scoreboard players set @s mall.pa_cooldown 2000
+playsound minecraft:block.note_block.bell ambient @s ~ ~ ~ 0.6 1.4
+tellraw @a [{"text":"[PA] ","color":"gray","italic":true},{"text":"Attention, sport. Our Cluck-O-Mart is offering a Buy-One-Get-One-Cursed deal on their Eternal Nuggets. Today only. All days are today only here.","color":"gold","italic":true}]

--- a/output/motfb-datapack/data/motfb/function/pa/job_offer.mcfunction
+++ b/output/motfb-datapack/data/motfb/function/pa/job_offer.mcfunction
@@ -1,0 +1,3 @@
+scoreboard players set @s mall.pa_cooldown 1200
+playsound minecraft:block.note_block.bell ambient @a ~ ~ ~ 0.8 1.2
+tellraw @a [{"text":"[PA] ","color":"gray","italic":true},{"text":"Attention, sport. Mall Office, third floor. The handle is warm. Don't shake my hand.","color":"dark_purple","italic":true}]

--- a/output/motfb-datapack/data/motfb/function/pa/pretzel_pitch.mcfunction
+++ b/output/motfb-datapack/data/motfb/function/pa/pretzel_pitch.mcfunction
@@ -1,0 +1,3 @@
+scoreboard players set @s mall.pa_cooldown 1600
+playsound minecraft:block.note_block.bell ambient @s ~ ~ ~ 0.6 1.4
+tellraw @a [{"text":"[PA] ","color":"gray","italic":true},{"text":"Hot pretzels at Pretzel-Pretzel Pretzel. The name says it all. Three times. Have you tried the pretzels? They are pretzels.","color":"gold","italic":true}]

--- a/output/motfb-datapack/data/motfb/function/pa/welcome.mcfunction
+++ b/output/motfb-datapack/data/motfb/function/pa/welcome.mcfunction
@@ -1,0 +1,3 @@
+scoreboard players set @s mall.pa_cooldown 1800
+playsound minecraft:block.note_block.bell ambient @s ~ ~ ~ 0.6 1.4
+tellraw @a [{"text":"[PA] ","color":"gray","italic":true},{"text":"Welcome, welcome! Welcome to Liminal Lakes Mall — America's #1 Family Destination, open late, open always. We've got such a great crowd today, champ. Just you. Just you. That's a great crowd. Please enjoy your visit.","color":"gold","italic":true}]

--- a/output/motfb-datapack/data/motfb/function/reset.mcfunction
+++ b/output/motfb-datapack/data/motfb/function/reset.mcfunction
@@ -73,6 +73,9 @@ clone -12 -3 -220 12 11 -200 -12 97 -220
 function motfb:lostkid/spawn_at_arcade
 function motfb:bryan/spawn_at_office
 
+# --- restore difficulty (reset may have been called after a server reload) ---
+difficulty hard
+
 # --- teleport players to spawn ---
 tp @a 0 65 -150
 

--- a/output/motfb-datapack/data/motfb/function/reset.mcfunction
+++ b/output/motfb-datapack/data/motfb/function/reset.mcfunction
@@ -1,0 +1,79 @@
+# --- score reset ---
+scoreboard players set #party mall.coupons 0
+scoreboard players set #party mall.journals 0
+scoreboard players set #party mall.ending 0
+scoreboard players set #party mall.bryan_phase 0
+scoreboard players reset * mall.flag
+scoreboard players reset @a mall.contract_use
+scoreboard players reset @a mall.shears_use
+scoreboard players reset @a mall.pa_cooldown
+scoreboard players reset @a mall.lk_cooldown
+scoreboard players reset @a mall.deaths
+
+# --- tag reset (per-player) ---
+tag @a remove has_contract
+tag @a remove gave_contract
+tag @a remove in_office
+tag @a remove lk_following
+tag @a remove journal1_found
+tag @a remove journal2_found
+tag @a remove journal3_found
+tag @a remove in_kraw
+tag @a remove in_searz
+tag @a remove in_pixellich
+tag @a remove in_cinnabog
+tag @a remove in_buildaboss
+tag @a remove in_hottopical
+tag @a remove in_spencers
+tag @a remove in_bathbody
+tag @a remove in_pretzel
+tag @a remove in_spunky
+
+# --- entity cleanup ---
+kill @e[tag=motfb_boss]
+kill @e[tag=motfb_bryan]
+kill @e[tag=motfb_lostkid]
+kill @e[type=arrow,tag=motfb_bryan_attack]
+
+# --- inventory cleanup ---
+clear @a minecraft:paper[custom_name='{"text":"BOSS COUPON","color":"gold","italic":false}']
+clear @a minecraft:carrot_on_a_stick[custom_model_data={floats:[1001.0f]}]
+
+# --- restore store doors (remove bedrock seals) ---
+fill -6 62 -260 -6 79 -246 minecraft:air replace minecraft:bedrock
+fill 6 62 -260 6 79 -246 minecraft:air replace minecraft:bedrock
+fill -6 62 -245 -6 79 -231 minecraft:air replace minecraft:bedrock
+fill 6 62 -245 6 79 -231 minecraft:air replace minecraft:bedrock
+fill -6 62 -230 -6 79 -216 minecraft:air replace minecraft:bedrock
+fill 6 62 -230 6 79 -216 minecraft:air replace minecraft:bedrock
+fill -6 62 -215 -6 79 -201 minecraft:air replace minecraft:bedrock
+fill 6 62 -215 6 79 -201 minecraft:air replace minecraft:bedrock
+fill -6 62 -200 -6 79 -186 minecraft:air replace minecraft:bedrock
+fill -50 62 -260 50 79 -248 minecraft:air replace minecraft:bedrock
+
+# --- restore escalator gate ---
+fill -1 65 -230 1 79 -228 minecraft:bedrock replace minecraft:air
+
+# --- restore storefronts from backup regions ---
+clone -50 -37 -260 -6 -21 -246 -50 62 -260
+clone 6 -37 -260 50 -21 -246 6 62 -260
+clone -50 -37 -245 -6 -21 -231 -50 62 -245
+clone 6 -37 -245 50 -21 -231 6 62 -245
+clone -50 -37 -230 -6 -21 -216 -50 62 -230
+clone 6 -37 -230 50 -21 -216 6 62 -230
+clone -50 -37 -215 -6 -21 -201 -50 62 -215
+clone 6 -37 -215 50 -21 -201 6 62 -215
+clone -50 -37 -200 -6 -21 -186 -50 62 -200
+clone -50 -37 -280 50 -21 -261 -50 62 -280
+
+# --- restore office from backup ---
+clone -12 -3 -220 12 11 -200 -12 97 -220
+
+# --- re-summon static NPCs ---
+function motfb:lostkid/spawn_at_arcade
+function motfb:bryan/spawn_at_office
+
+# --- teleport players to spawn ---
+tp @a 0 65 -150
+
+tellraw @a {"text":"The mall is open. Welcome, welcome, welcome.","color":"gold","italic":true}

--- a/output/motfb-datapack/data/motfb/function/tick.mcfunction
+++ b/output/motfb-datapack/data/motfb/function/tick.mcfunction
@@ -1,0 +1,43 @@
+# --- decay PA + lost-kid cooldowns ---
+execute as @a if score @s mall.pa_cooldown matches 1.. run scoreboard players remove @s mall.pa_cooldown 1
+execute as @a if score @s mall.lk_cooldown matches 1.. run scoreboard players remove @s mall.lk_cooldown 1
+
+# --- contract item use → fan out to ending handlers ---
+execute as @a[tag=has_contract] if score @s mall.contract_use matches 1.. run function motfb:contract/sign
+execute as @a[tag=has_contract] if score @s mall.shears_use matches 1.. run function motfb:contract/tear
+scoreboard players reset @a mall.contract_use
+scoreboard players reset @a mall.shears_use
+
+# --- re-give lost contract ---
+execute as @a[tag=has_contract] run execute store result score @s mall.contract_held run clear @s minecraft:carrot_on_a_stick[custom_model_data={floats:[1001.0f]}] 0
+execute as @a[tag=has_contract] if score @s mall.contract_held matches 0 run function motfb:contract/give
+
+# --- Bryan vulnerability gate: flip off invulnerability once any player has contract ---
+execute if entity @a[tag=has_contract] if entity @e[tag=motfb_bryan] run data merge entity @e[tag=motfb_bryan,limit=1] {Invulnerable:0b,NoAI:0b}
+
+# --- Bryan HP probe (only while fight active) ---
+execute if score #party mall.bryan_phase matches 1..2 run function motfb:bryan/hp_probe
+
+# --- Bryan attack clock (phase 1 only) ---
+execute if score #party mall.bryan_phase matches 1 run scoreboard players add #bryan_atk_clk mall.flag 1
+execute if score #party mall.bryan_phase matches 1 if score #bryan_atk_clk mall.flag matches 60.. as @e[tag=motfb_bryan,tag=motfb_bryan_phase1,limit=1] at @s run summon arrow ~ ~1.6 ~ {Tags:["motfb_bryan_attack"],damage:6.0d,pickup:2b}
+execute if score #party mall.bryan_phase matches 1 if score #bryan_atk_clk mall.flag matches 60.. run scoreboard players set #bryan_atk_clk mall.flag 0
+
+# --- Boss bar updates while bosses alive ---
+execute if entity @e[tag=motfb_kraw_boss] run execute store result bossbar motfb:kraw value run data get entity @e[tag=motfb_kraw_boss,limit=1] Health
+execute if entity @e[tag=motfb_searz_boss] run execute store result bossbar motfb:searz value run data get entity @e[tag=motfb_searz_boss,limit=1] Health
+execute if entity @e[tag=motfb_pixellich_boss] run execute store result bossbar motfb:pixellich value run data get entity @e[tag=motfb_pixellich_boss,limit=1] Health
+execute if entity @e[tag=motfb_candywitch_boss] run execute store result bossbar motfb:candywitch value run data get entity @e[tag=motfb_candywitch_boss,limit=1] Health
+execute if entity @e[tag=motfb_stitchlord_boss] run execute store result bossbar motfb:stitchlord value run data get entity @e[tag=motfb_stitchlord_boss,limit=1] Health
+execute if entity @e[tag=motfb_vampirequeen_boss] run execute store result bossbar motfb:vampirequeen value run data get entity @e[tag=motfb_vampirequeen_boss,limit=1] Health
+execute if entity @e[tag=motfb_impswarm_boss] run execute store result bossbar motfb:impswarm value run data get entity @e[tag=motfb_impswarm_boss,limit=1] Health
+execute if entity @e[tag=motfb_exiledsaint_boss] run execute store result bossbar motfb:exiledsaint value run data get entity @e[tag=motfb_exiledsaint_boss,limit=1] Health
+execute if entity @e[tag=motfb_knotgod_boss] run execute store result bossbar motfb:knotgod value run data get entity @e[tag=motfb_knotgod_boss,limit=1] Health
+execute if entity @e[tag=motfb_speeddemon_boss] run execute store result bossbar motfb:speeddemon value run data get entity @e[tag=motfb_speeddemon_boss,limit=1] Health
+execute if entity @e[tag=motfb_bryan] run execute store result bossbar motfb:bryan value run data get entity @e[tag=motfb_bryan,limit=1] Health
+
+# --- Lost Kid follow tick ---
+execute if entity @e[tag=motfb_lostkid] run function motfb:lostkid/follow_tick
+
+# --- visit-end title on death ---
+execute as @a if score @s mall.deaths matches 1.. run function motfb:utils/visit_ended

--- a/output/motfb-datapack/data/motfb/function/tick.mcfunction
+++ b/output/motfb-datapack/data/motfb/function/tick.mcfunction
@@ -10,7 +10,10 @@ scoreboard players reset @a mall.shears_use
 
 # --- re-give lost contract ---
 execute as @a[tag=has_contract] run execute store result score @s mall.contract_held run clear @s minecraft:carrot_on_a_stick[custom_model_data={floats:[1001.0f]}] 0
-execute as @a[tag=has_contract] if score @s mall.contract_held matches 0 run function motfb:contract/give
+# first-time: contract/give handles proximity-tag, item give, and PA announcement
+execute as @a[tag=has_contract,tag=!gave_contract] if score @s mall.contract_held matches 0 run function motfb:contract/give
+# re-give: silent restore — no PA (this is what caused chat spam when @s had gave_contract but lost the item)
+execute as @a[tag=has_contract,tag=gave_contract] if score @s mall.contract_held matches 0 run give @s minecraft:carrot_on_a_stick[custom_model_data={floats:[1001.0f]},custom_name='{"text":"The Original Contract","color":"dark_purple","italic":false,"bold":true}',lore=['{"text":"PARTY OF THE FIRST PART:","color":"dark_gray","italic":false}','{"text":"  The Architect of All Endings","color":"gray","italic":true}','{"text":"","color":"gray"}','{"text":"Right-click on the Signing Lectern: ACCEPT","color":"gold","italic":false}','{"text":"Strike Bryan with a weapon: VOID","color":"red","italic":false}','{"text":"Use Shears while standing on the Tearing Pad: ANNUL","color":"light_purple","italic":false}','{"text":"  (3 journals required)","color":"light_purple","italic":false}']] 1
 
 # --- Bryan vulnerability gate: flip off invulnerability once any player has contract ---
 execute if entity @a[tag=has_contract] if entity @e[tag=motfb_bryan] run data merge entity @e[tag=motfb_bryan,limit=1] {Invulnerable:0b,NoAI:0b}

--- a/output/motfb-datapack/data/motfb/function/tick.mcfunction
+++ b/output/motfb-datapack/data/motfb/function/tick.mcfunction
@@ -23,17 +23,71 @@ execute if score #party mall.bryan_phase matches 1 run scoreboard players add #b
 execute if score #party mall.bryan_phase matches 1 if score #bryan_atk_clk mall.flag matches 60.. as @e[tag=motfb_bryan,tag=motfb_bryan_phase1,limit=1] at @s run summon arrow ~ ~1.6 ~ {Tags:["motfb_bryan_attack"],damage:6.0d,pickup:2b}
 execute if score #party mall.bryan_phase matches 1 if score #bryan_atk_clk mall.flag matches 60.. run scoreboard players set #bryan_atk_clk mall.flag 0
 
-# --- Boss bar updates while bosses alive ---
+# --- Boss bar: continuous presence detection + HP value + player list updates ---
+# Pattern per boss: add tag for entrants, remove for leavers, then update bar value + players.
+# on_death_* handles tag removal and bossbar remove when the boss dies.
+
+# kraw (Cluck-O-Mart left)
+execute if entity @e[tag=motfb_kraw_boss] as @a[x=-50,y=60,z=-260,dx=44,dy=20,dz=14,tag=!in_kraw] run tag @s add in_kraw
+execute as @a[tag=in_kraw] unless entity @s[x=-50,y=60,z=-260,dx=44,dy=20,dz=14] run tag @s remove in_kraw
 execute if entity @e[tag=motfb_kraw_boss] run execute store result bossbar motfb:kraw value run data get entity @e[tag=motfb_kraw_boss,limit=1] Health
+execute if entity @e[tag=motfb_kraw_boss] run bossbar set motfb:kraw players @a[tag=in_kraw]
+
+# searz (SEARZ dept-store upper)
+execute if entity @e[tag=motfb_searz_boss] as @a[x=-50,y=60,z=-280,dx=100,dy=20,dz=19,tag=!in_searz] run tag @s add in_searz
+execute as @a[tag=in_searz] unless entity @s[x=-50,y=60,z=-280,dx=100,dy=20,dz=19] run tag @s remove in_searz
 execute if entity @e[tag=motfb_searz_boss] run execute store result bossbar motfb:searz value run data get entity @e[tag=motfb_searz_boss,limit=1] Health
+execute if entity @e[tag=motfb_searz_boss] run bossbar set motfb:searz players @a[tag=in_searz]
+
+# pixellich (GameZone left)
+execute if entity @e[tag=motfb_pixellich_boss] as @a[x=-50,y=60,z=-245,dx=44,dy=20,dz=14,tag=!in_pixellich] run tag @s add in_pixellich
+execute as @a[tag=in_pixellich] unless entity @s[x=-50,y=60,z=-245,dx=44,dy=20,dz=14] run tag @s remove in_pixellich
 execute if entity @e[tag=motfb_pixellich_boss] run execute store result bossbar motfb:pixellich value run data get entity @e[tag=motfb_pixellich_boss,limit=1] Health
+execute if entity @e[tag=motfb_pixellich_boss] run bossbar set motfb:pixellich players @a[tag=in_pixellich]
+
+# candywitch (Cinnabog left)
+execute if entity @e[tag=motfb_candywitch_boss] as @a[x=-50,y=60,z=-230,dx=44,dy=20,dz=14,tag=!in_cinnabog] run tag @s add in_cinnabog
+execute as @a[tag=in_cinnabog] unless entity @s[x=-50,y=60,z=-230,dx=44,dy=20,dz=14] run tag @s remove in_cinnabog
 execute if entity @e[tag=motfb_candywitch_boss] run execute store result bossbar motfb:candywitch value run data get entity @e[tag=motfb_candywitch_boss,limit=1] Health
+execute if entity @e[tag=motfb_candywitch_boss] run bossbar set motfb:candywitch players @a[tag=in_cinnabog]
+
+# stitchlord (Build-A-Boss left)
+execute if entity @e[tag=motfb_stitchlord_boss] as @a[x=-50,y=60,z=-215,dx=44,dy=20,dz=14,tag=!in_buildaboss] run tag @s add in_buildaboss
+execute as @a[tag=in_buildaboss] unless entity @s[x=-50,y=60,z=-215,dx=44,dy=20,dz=14] run tag @s remove in_buildaboss
 execute if entity @e[tag=motfb_stitchlord_boss] run execute store result bossbar motfb:stitchlord value run data get entity @e[tag=motfb_stitchlord_boss,limit=1] Health
+execute if entity @e[tag=motfb_stitchlord_boss] run bossbar set motfb:stitchlord players @a[tag=in_buildaboss]
+
+# vampirequeen (Hot-Topical left)
+execute if entity @e[tag=motfb_vampirequeen_boss] as @a[x=-50,y=60,z=-200,dx=44,dy=20,dz=14,tag=!in_hottopical] run tag @s add in_hottopical
+execute as @a[tag=in_hottopical] unless entity @s[x=-50,y=60,z=-200,dx=44,dy=20,dz=14] run tag @s remove in_hottopical
 execute if entity @e[tag=motfb_vampirequeen_boss] run execute store result bossbar motfb:vampirequeen value run data get entity @e[tag=motfb_vampirequeen_boss,limit=1] Health
+execute if entity @e[tag=motfb_vampirequeen_boss] run bossbar set motfb:vampirequeen players @a[tag=in_hottopical]
+
+# impswarm (Spencer's right)
+execute if entity @e[tag=motfb_impswarm_boss] as @a[x=6,y=60,z=-260,dx=44,dy=20,dz=14,tag=!in_spencers] run tag @s add in_spencers
+execute as @a[tag=in_spencers] unless entity @s[x=6,y=60,z=-260,dx=44,dy=20,dz=14] run tag @s remove in_spencers
 execute if entity @e[tag=motfb_impswarm_boss] run execute store result bossbar motfb:impswarm value run data get entity @e[tag=motfb_impswarm_boss,limit=1] Health
+execute if entity @e[tag=motfb_impswarm_boss] run bossbar set motfb:impswarm players @a[tag=in_spencers]
+
+# exiledsaint (Bath & Body right)
+execute if entity @e[tag=motfb_exiledsaint_boss] as @a[x=6,y=60,z=-245,dx=44,dy=20,dz=14,tag=!in_bathbody] run tag @s add in_bathbody
+execute as @a[tag=in_bathbody] unless entity @s[x=6,y=60,z=-245,dx=44,dy=20,dz=14] run tag @s remove in_bathbody
 execute if entity @e[tag=motfb_exiledsaint_boss] run execute store result bossbar motfb:exiledsaint value run data get entity @e[tag=motfb_exiledsaint_boss,limit=1] Health
+execute if entity @e[tag=motfb_exiledsaint_boss] run bossbar set motfb:exiledsaint players @a[tag=in_bathbody]
+
+# knotgod (Pretzel-Pretzel Pretzel right)
+execute if entity @e[tag=motfb_knotgod_boss] as @a[x=6,y=60,z=-230,dx=44,dy=20,dz=14,tag=!in_pretzel] run tag @s add in_pretzel
+execute as @a[tag=in_pretzel] unless entity @s[x=6,y=60,z=-230,dx=44,dy=20,dz=14] run tag @s remove in_pretzel
 execute if entity @e[tag=motfb_knotgod_boss] run execute store result bossbar motfb:knotgod value run data get entity @e[tag=motfb_knotgod_boss,limit=1] Health
+execute if entity @e[tag=motfb_knotgod_boss] run bossbar set motfb:knotgod players @a[tag=in_pretzel]
+
+# speeddemon (Spunky's Footwear right)
+execute if entity @e[tag=motfb_speeddemon_boss] as @a[x=6,y=60,z=-215,dx=44,dy=20,dz=14,tag=!in_spunky] run tag @s add in_spunky
+execute as @a[tag=in_spunky] unless entity @s[x=6,y=60,z=-215,dx=44,dy=20,dz=14] run tag @s remove in_spunky
 execute if entity @e[tag=motfb_speeddemon_boss] run execute store result bossbar motfb:speeddemon value run data get entity @e[tag=motfb_speeddemon_boss,limit=1] Health
+execute if entity @e[tag=motfb_speeddemon_boss] run bossbar set motfb:speeddemon players @a[tag=in_spunky]
+
+# bryan (office fight — no bounding box; all players see the bar)
 execute if entity @e[tag=motfb_bryan] run execute store result bossbar motfb:bryan value run data get entity @e[tag=motfb_bryan,limit=1] Health
 
 # --- Lost Kid follow tick ---

--- a/output/motfb-datapack/data/motfb/function/utils/give_coupon.mcfunction
+++ b/output/motfb-datapack/data/motfb/function/utils/give_coupon.mcfunction
@@ -1,0 +1,11 @@
+scoreboard players add #party mall.coupons 1
+
+give @a[tag=in_active_store] minecraft:paper[custom_name='{"text":"BOSS COUPON","color":"gold","italic":false}',lore=['{"text":"Liminal Lakes Mall","color":"gray","italic":false}','{"text":"Authorized signature on file","color":"dark_gray","italic":true}']] 1
+
+playsound minecraft:block.note_block.chime ambient @a ~ ~ ~ 1 1.4
+
+execute as @a[tag=in_active_store] at @s run title @s times 10 60 20
+execute as @a[tag=in_active_store] at @s run title @s subtitle {"text":"+1 Coupon","color":"yellow"}
+execute as @a[tag=in_active_store] at @s run title @s title {"text":"BOSS DEFEATED","color":"gold"}
+
+execute if score #party mall.coupons matches 10.. run function motfb:contract/unlock_office

--- a/output/motfb-datapack/data/motfb/function/utils/pa_say.mcfunction
+++ b/output/motfb-datapack/data/motfb/function/utils/pa_say.mcfunction
@@ -1,0 +1,1 @@
+playsound minecraft:block.note_block.bell ambient @a ~ ~ ~ 0.6 1.4

--- a/output/motfb-datapack/data/motfb/function/utils/teleport_escape.mcfunction
+++ b/output/motfb-datapack/data/motfb/function/utils/teleport_escape.mcfunction
@@ -1,0 +1,4 @@
+tp @a 0 65 -88
+title @a times 20 80 20
+title @a title {"text":"YOU ESCAPED","color":"white","bold":true}
+title @a subtitle {"text":"The mall is closed.","color":"gray","italic":true}

--- a/output/motfb-datapack/data/motfb/function/utils/visit_ended.mcfunction
+++ b/output/motfb-datapack/data/motfb/function/utils/visit_ended.mcfunction
@@ -1,0 +1,5 @@
+title @s times 5 60 20
+title @s subtitle {"text":"THANK YOU FOR SHOPPING WITH US","color":"gray","italic":true}
+title @s title {"text":"YOUR VISIT HAS ENDED","color":"red","bold":true}
+playsound minecraft:block.note_block.bell ambient @s ~ ~ ~ 1 0.5
+scoreboard players reset @s mall.deaths

--- a/output/motfb-datapack/data/motfb/predicate/in_mall_bounds.json
+++ b/output/motfb-datapack/data/motfb/predicate/in_mall_bounds.json
@@ -1,0 +1,10 @@
+{
+  "condition": "minecraft:location_check",
+  "predicate": {
+    "position": {
+      "x": { "min": -52, "max": 52 },
+      "y": { "min": 59, "max": 116 },
+      "z": { "min": -282, "max": -98 }
+    }
+  }
+}

--- a/output/motfb-datapack/data/motfb/tag/function/load.json
+++ b/output/motfb-datapack/data/motfb/tag/function/load.json
@@ -1,0 +1,1 @@
+{ "values": ["motfb:init"] }

--- a/output/motfb-datapack/data/motfb/tag/function/tick.json
+++ b/output/motfb-datapack/data/motfb/tag/function/tick.json
@@ -1,0 +1,1 @@
+{ "values": ["motfb:tick"] }

--- a/output/motfb-datapack/pack.mcmeta
+++ b/output/motfb-datapack/pack.mcmeta
@@ -1,0 +1,6 @@
+{
+  "pack": {
+    "pack_format": 81,
+    "description": "Mall of the Final Bosses — custom mechanics"
+  }
+}

--- a/scripts/motfb-deploy.sh
+++ b/scripts/motfb-deploy.sh
@@ -1,0 +1,88 @@
+#!/usr/bin/env bash
+# Push the current branch's datapack to the live minecraft-papermc container
+# and verify difficulty flips to Hard.
+#
+# Usage: motfb-deploy.sh [--help]
+#
+# Source:      output/motfb-datapack  (repo root)
+# Destination: /data/Times_Square__NYC/datapacks/motfb  (in container)
+
+set -euo pipefail
+
+CONTAINER="minecraft-papermc"
+WORLD="Times_Square__NYC"
+DATAPACK_DEST="/data/$WORLD/datapacks/motfb"
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+REPO_ROOT="$(cd "$SCRIPT_DIR/.." && pwd)"
+DATAPACK_SRC="$REPO_ROOT/output/motfb-datapack"
+
+usage() {
+    cat <<'EOF'
+Usage: motfb-deploy.sh [--help]
+
+Deploys the current branch HEAD datapack to the live minecraft-papermc container.
+
+  Source:      <repo>/output/motfb-datapack
+  Destination: /data/Times_Square__NYC/datapacks/motfb  (inside container)
+
+Steps:
+  1. Validates container is running and source datapack exists
+  2. Replaces the live datapack via docker cp
+  3. Reloads datapacks via rcon
+  4. Runs motfb:init and verifies difficulty is Hard
+  5. Exits non-zero on any failure
+
+Exit codes:
+  0  deploy successful; difficulty confirmed Hard
+  1  validation or runtime error
+EOF
+    exit 0
+}
+
+[[ "${1:-}" == "--help" || "${1:-}" == "-h" ]] && usage
+
+if [[ ! -d "$DATAPACK_SRC" ]]; then
+    echo "Error: datapack not found at $DATAPACK_SRC" >&2
+    exit 1
+fi
+
+if ! docker inspect --format='{{.State.Running}}' "$CONTAINER" 2>/dev/null | grep -q "true"; then
+    echo "Error: container '$CONTAINER' is not running" >&2
+    exit 1
+fi
+
+echo "==> Removing existing datapack from container..."
+docker exec "$CONTAINER" rm -rf "$DATAPACK_DEST"
+
+echo "==> Copying $DATAPACK_SRC -> $CONTAINER:$DATAPACK_DEST"
+docker cp "$DATAPACK_SRC" "$CONTAINER:$DATAPACK_DEST"
+
+echo "==> Setting ownership..."
+docker exec "$CONTAINER" chown -R minecraft:minecraft "$DATAPACK_DEST"
+
+echo "==> Reloading datapacks..."
+docker exec "$CONTAINER" rcon-cli reload
+
+echo "==> Running motfb:init..."
+INIT_OUT=$(docker exec "$CONTAINER" rcon-cli "function motfb:init" 2>&1)
+echo "$INIT_OUT"
+if echo "$INIT_OUT" | grep -qiE "(error|unknown function|no function|failed)"; then
+    echo "ERROR: motfb:init reported an error" >&2
+    exit 1
+fi
+
+echo "==> Verifying difficulty is Hard..."
+DIFF_OUT=$(docker exec "$CONTAINER" rcon-cli "difficulty" 2>&1)
+echo "$DIFF_OUT"
+if ! echo "$DIFF_OUT" | grep -qi "hard"; then
+    echo "ERROR: difficulty is not Hard after motfb:init — got: $DIFF_OUT" >&2
+    exit 1
+fi
+
+echo ""
+echo "=== Deploy successful ==="
+echo "  Container:  $CONTAINER"
+echo "  World:      $WORLD"
+echo "  Datapack:   $DATAPACK_DEST"
+echo "  Difficulty: Hard ✓"

--- a/scripts/motfb-package-world.sh
+++ b/scripts/motfb-package-world.sh
@@ -1,0 +1,75 @@
+#!/usr/bin/env bash
+# Rebuild the MOTFB world zip from the live container's current world state.
+#
+# Usage: motfb-package-world.sh <zip-name> [--help]
+#
+# Pulls Times_Square__NYC from the live container and writes
+# /home/jason/motfb-docs/<zip-name>.zip, overwriting any existing file.
+# Run this after motfb-deploy.sh confirms the container matches HEAD.
+
+set -euo pipefail
+
+CONTAINER="minecraft-papermc"
+WORLD="Times_Square__NYC"
+WORLD_IN_CONTAINER="/data/$WORLD"
+MOTFB_DOCS="/home/jason/motfb-docs"
+
+usage() {
+    cat <<'EOF'
+Usage: motfb-package-world.sh <zip-name>
+
+  <zip-name>   Output filename without .zip, e.g. motfb-phase-d-rev2
+
+Pulls the live container world and writes /home/jason/motfb-docs/<zip-name>.zip.
+Run after scripts/motfb-deploy.sh has confirmed the container matches HEAD and
+all sibling sub-issues have merged to the branch.
+
+Exit codes:
+  0  zip written successfully
+  1  validation or runtime error
+EOF
+    exit 0
+}
+
+[[ "${1:-}" == "--help" || "${1:-}" == "-h" ]] && usage
+
+if [[ $# -lt 1 ]]; then
+    echo "Error: missing <zip-name>" >&2
+    echo "Run '$0 --help' for usage." >&2
+    exit 1
+fi
+
+ZIP_NAME="$1"
+
+if [[ "$ZIP_NAME" == *".."* || "$ZIP_NAME" == *"/"* ]]; then
+    echo "Error: zip name contains invalid characters: $ZIP_NAME" >&2
+    exit 1
+fi
+
+OUTPUT_ZIP="$MOTFB_DOCS/${ZIP_NAME}.zip"
+
+if ! docker inspect --format='{{.State.Running}}' "$CONTAINER" 2>/dev/null | grep -q "true"; then
+    echo "Error: container '$CONTAINER' is not running" >&2
+    exit 1
+fi
+
+if [[ ! -d "$MOTFB_DOCS" ]]; then
+    echo "Error: motfb-docs directory not found: $MOTFB_DOCS" >&2
+    exit 1
+fi
+
+TMPDIR_WORLD=$(mktemp -d)
+trap 'rm -rf "$TMPDIR_WORLD"' EXIT
+
+echo "==> Pulling world from $CONTAINER:$WORLD_IN_CONTAINER..."
+docker cp "$CONTAINER:$WORLD_IN_CONTAINER" "$TMPDIR_WORLD/$WORLD"
+
+echo "==> Building zip: $OUTPUT_ZIP..."
+rm -f "$OUTPUT_ZIP"
+(cd "$TMPDIR_WORLD" && zip -r "$OUTPUT_ZIP" "$WORLD" -x "*.lock" -x "session.lock")
+
+echo ""
+echo "=== Package complete ==="
+echo "  World:  $WORLD"
+echo "  Output: $OUTPUT_ZIP"
+echo "  Size:   $(du -sh "$OUTPUT_ZIP" | cut -f1)"

--- a/scripts/motfb-smoke.sh
+++ b/scripts/motfb-smoke.sh
@@ -1,0 +1,163 @@
+#!/usr/bin/env bash
+# Smoke-test a datapack against the live minecraft-papermc Docker container.
+#
+# Usage: motfb-smoke.sh [--help] <datapack-path> [function1 function2 ...]
+
+set -euo pipefail
+
+CONTAINER="minecraft-papermc"
+WORLD="Times_Square__NYC"
+DATAPACKS_PATH="/data/$WORLD/datapacks"
+
+usage() {
+    cat <<'EOF'
+Usage: motfb-smoke.sh <datapack-path> [function1 function2 ...]
+
+  <datapack-path>   local path to a datapack directory (must exist)
+  [function...]     datapack functions to invoke via rcon after enabling the pack
+
+Guardrails enforced:
+  - Temp pack is always prefixed smoke_test_ and auto-cleaned via trap (success or error)
+  - Only datapacks/ is touched; world data files are never modified
+  - Forbidden commands (/op /stop /save-off /ban /kick) are never sent to rcon
+
+Exit codes:
+  0  pack accepted; all requested functions ran without error
+  1  validation or runtime error
+EOF
+    exit 0
+}
+
+[[ "${1:-}" == "--help" || "${1:-}" == "-h" ]] && usage
+
+if [[ $# -lt 1 ]]; then
+    echo "Error: missing <datapack-path>" >&2
+    echo "Run '$0 --help' for usage." >&2
+    exit 1
+fi
+
+PACK_PATH="$1"; shift
+FUNCTIONS=("$@")
+
+# --- Input validation ---
+
+if [[ ! -e "$PACK_PATH" ]]; then
+    echo "Error: datapack path does not exist: $PACK_PATH" >&2
+    exit 1
+fi
+
+PACK_NAME="$(basename "${PACK_PATH%/}")"
+
+# Guard against path traversal in the pack name
+if [[ "$PACK_NAME" == *".."* || "$PACK_NAME" == *"/"* ]]; then
+    echo "Error: pack name contains invalid characters: $PACK_NAME" >&2
+    exit 1
+fi
+
+SMOKE_NAME="smoke_test_${PACK_NAME}"
+REMOTE_PACK="$DATAPACKS_PATH/$SMOKE_NAME"
+
+# Guardrail: the destination must stay inside DATAPACKS_PATH
+RESOLVED_REMOTE="$(realpath -m "$REMOTE_PACK")"
+RESOLVED_DATAPACKS="$(realpath -m "$DATAPACKS_PATH")"
+if [[ "$RESOLVED_REMOTE" != "$RESOLVED_DATAPACKS"/* ]]; then
+    echo "Error: resolved remote path escapes datapacks dir: $RESOLVED_REMOTE" >&2
+    exit 1
+fi
+
+# Guardrail: reject forbidden command names in the function list
+FORBIDDEN=(op stop save-off ban kick)
+for fn in "${FUNCTIONS[@]+"${FUNCTIONS[@]}"}"; do
+    fn_basename="${fn##*:}"
+    for bad in "${FORBIDDEN[@]}"; do
+        if [[ "$fn_basename" == "$bad" ]]; then
+            echo "Error: forbidden function name '$fn'" >&2
+            exit 1
+        fi
+    done
+done
+
+# Verify the container is running
+if ! docker inspect --format='{{.State.Running}}' "$CONTAINER" 2>/dev/null | grep -q "true"; then
+    echo "Error: container '$CONTAINER' is not running" >&2
+    exit 1
+fi
+
+# --- Cleanup trap ---
+# Runs on exit (success or error): removes the smoke pack and reloads datapacks.
+cleanup() {
+    local rc=$?
+    echo ""
+    echo "==> Cleanup: removing $SMOKE_NAME from container..."
+    docker exec "$CONTAINER" rm -rf "$REMOTE_PACK" 2>/dev/null || true
+    docker exec "$CONTAINER" rcon-cli reload >/dev/null 2>&1 || true
+    exit $rc
+}
+trap cleanup EXIT
+
+# Record log anchor before we do anything so log grep is scoped to this run
+LOG_SINCE=$(date -u +"%Y-%m-%dT%H:%M:%SZ")
+
+# --- Deploy pack ---
+
+echo "==> Copying pack -> $CONTAINER:$REMOTE_PACK"
+docker cp "$PACK_PATH" "$CONTAINER:$REMOTE_PACK"
+
+echo "==> Setting ownership..."
+docker exec "$CONTAINER" chown -R minecraft:minecraft "$REMOTE_PACK"
+
+# --- Reload and enable ---
+
+echo "==> Reloading datapacks..."
+docker exec "$CONTAINER" rcon-cli reload
+
+echo "==> Enabling pack: file/$SMOKE_NAME"
+ENABLE_OUT=$(docker exec "$CONTAINER" rcon-cli "datapack enable \"file/$SMOKE_NAME\"" 2>&1) || true
+echo "$ENABLE_OUT"
+
+ERRORS=0
+
+if echo "$ENABLE_OUT" | grep -qiE "(unknown|no such|failed|error)"; then
+    echo "ERROR: pack enable rejected or failed" >&2
+    ERRORS=$((ERRORS + 1))
+fi
+
+# --- Capture pack_format and log warnings ---
+
+echo ""
+echo "==> Scanning container logs for pack_format / WARN / ERROR..."
+LOG_HITS=$(docker logs --since "$LOG_SINCE" "$CONTAINER" 2>&1 | grep -iE "(pack_format|WARN|ERROR)" || true)
+if [[ -n "$LOG_HITS" ]]; then
+    echo "--- relevant log lines ---"
+    echo "$LOG_HITS"
+else
+    echo "(no pack_format/WARN/ERROR lines in last 100 log lines)"
+fi
+
+# --- Run requested functions ---
+
+if [[ ${#FUNCTIONS[@]} -gt 0 ]]; then
+    echo ""
+    echo "==> Running ${#FUNCTIONS[@]} function(s)..."
+    for fn in "${FUNCTIONS[@]}"; do
+        echo "--- function: $fn ---"
+        FN_OUT=$(docker exec "$CONTAINER" rcon-cli "function $fn" 2>&1) || true
+        echo "$FN_OUT"
+        if echo "$FN_OUT" | grep -qiE "(error|unknown function|no function|failed)"; then
+            echo "WARNING: function '$fn' reported an error" >&2
+            ERRORS=$((ERRORS + 1))
+        fi
+    done
+fi
+
+# --- Summary ---
+
+echo ""
+echo "=== Smoke Test Summary ==="
+echo "  Pack:        $PACK_NAME"
+echo "  Smoke name:  $SMOKE_NAME"
+echo "  Functions:   ${#FUNCTIONS[@]} invoked, $ERRORS error(s)"
+[[ -n "$LOG_HITS" ]] && echo "  Log hits:    (see above)"
+echo "=========================="
+
+[[ $ERRORS -eq 0 ]]

--- a/scripts/motfb-smoke.sh
+++ b/scripts/motfb-smoke.sh
@@ -39,6 +39,17 @@ fi
 PACK_PATH="$1"; shift
 FUNCTIONS=("$@")
 
+# --- Pre-merge audit: reject command-block payloads containing debug leftovers ---
+# Checks non-comment lines in .mcfunction files for say/test/debug commands.
+echo "==> Pre-merge audit: scanning for debug command-block payloads..."
+DEBUG_HITS=$(grep -rn --include="*.mcfunction" -E '(^|\brun\s+)(say|test|debug)\s' "$PACK_PATH" 2>/dev/null || true)
+if [[ -n "$DEBUG_HITS" ]]; then
+    echo "ERROR: debug command-block payloads detected — remove before merging:" >&2
+    echo "$DEBUG_HITS" >&2
+    exit 1
+fi
+echo "(no debug payloads found)"
+
 # --- Input validation ---
 
 if [[ ! -e "$PACK_PATH" ]]; then

--- a/scripts/motfb-verify-deployed.sh
+++ b/scripts/motfb-verify-deployed.sh
@@ -1,0 +1,73 @@
+#!/usr/bin/env bash
+# Verify the live container's deployed datapack matches the current branch HEAD.
+#
+# Usage: motfb-verify-deployed.sh [--help]
+#
+# Diffs the live container's /data/Times_Square__NYC/datapacks/motfb against
+# output/motfb-datapack in the current worktree. Exits non-zero and names any
+# divergent files on mismatch.
+
+set -euo pipefail
+
+CONTAINER="minecraft-papermc"
+WORLD="Times_Square__NYC"
+DATAPACK_IN_CONTAINER="/data/$WORLD/datapacks/motfb"
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+REPO_ROOT="$(cd "$SCRIPT_DIR/.." && pwd)"
+DATAPACK_SRC="$REPO_ROOT/output/motfb-datapack"
+
+usage() {
+    cat <<'EOF'
+Usage: motfb-verify-deployed.sh [--help]
+
+Checks that the live container's deployed datapack matches the current branch HEAD.
+
+  HEAD source: <repo>/output/motfb-datapack
+  Live source: /data/Times_Square__NYC/datapacks/motfb  (inside container)
+
+Exit codes:
+  0  live container matches HEAD exactly
+  1  mismatch or infrastructure error; divergent files printed to stderr
+EOF
+    exit 0
+}
+
+[[ "${1:-}" == "--help" || "${1:-}" == "-h" ]] && usage
+
+if [[ ! -d "$DATAPACK_SRC" ]]; then
+    echo "Error: local datapack not found at $DATAPACK_SRC" >&2
+    exit 1
+fi
+
+if ! docker inspect --format='{{.State.Running}}' "$CONTAINER" 2>/dev/null | grep -q "true"; then
+    echo "Error: container '$CONTAINER' is not running" >&2
+    exit 1
+fi
+
+TMPDIR_VERIFY=$(mktemp -d)
+trap 'rm -rf "$TMPDIR_VERIFY"' EXIT
+
+echo "==> Pulling deployed datapack from $CONTAINER:$DATAPACK_IN_CONTAINER..."
+docker cp "$CONTAINER:$DATAPACK_IN_CONTAINER" "$TMPDIR_VERIFY/motfb"
+
+echo "==> Diffing live container against local HEAD..."
+DIFF_EXIT=0
+DIFF_DETAIL=$(diff -r "$DATAPACK_SRC" "$TMPDIR_VERIFY/motfb" 2>&1) || DIFF_EXIT=$?
+
+if [[ $DIFF_EXIT -ne 0 ]]; then
+    echo ""
+    echo "ERROR: Live container datapack does NOT match HEAD." >&2
+    echo "Run scripts/motfb-deploy.sh to sync." >&2
+    echo ""
+    echo "Divergent files:" >&2
+    diff -rq "$DATAPACK_SRC" "$TMPDIR_VERIFY/motfb" 2>&1 \
+        | sed "s|$DATAPACK_SRC|HEAD|g; s|$TMPDIR_VERIFY/motfb|LIVE|g" >&2
+    exit 1
+fi
+
+echo ""
+echo "=== Verification passed ==="
+echo "  Live container matches HEAD"
+echo "  HEAD:  $DATAPACK_SRC"
+echo "  Live:  $CONTAINER:$DATAPACK_IN_CONTAINER"


### PR DESCRIPTION
Resolves [MIN-165](/MIN/issues/MIN-165)

## What's in this PR

- **scripts/motfb-deploy.sh** — deploys `output/motfb-datapack` to the live container via `docker cp`, reloads datapacks, runs `motfb:init`, asserts difficulty is Hard; exits non-zero on any failure
- **scripts/motfb-verify-deployed.sh** — diffs the live container's `/data/Times_Square__NYC/datapacks/motfb` against the worktree `output/motfb-datapack`; exits 0 on match, non-zero with named divergent files on mismatch
- **scripts/motfb-package-world.sh** — pulls the live world from the container and writes `/home/jason/motfb-docs/<name>.zip`; intended to run after all siblings land
- **docs/smoke-testing.md** — new Deploy runbook section with the mandatory 3-step close sequence

## AGENTS.md updates (not in this branch — live in agents/)

Updated DevOps Lead, Game Developer, and Scene Designer AGENTS.md files to include the mandatory post-commit deploy + verify step as part of issue close.