### PR TITLE
MIN-168: fix resource pack zip wrapper + migrate both pack.mcmeta to min/max_format schema

### DIFF
--- a/docs/smoke-testing.md
+++ b/docs/smoke-testing.md
@@ -97,6 +97,52 @@ at the call site:
 | Host volume | `/home/jason/minecraft-server/data/` ↔ `/data/` |
 | `function-permission-level` | 2 |
 
+## Deploy runbook
+
+### When to deploy
+
+Deploy whenever a sub-issue that touches the datapack is marked `done` and CI is
+green. Never rely on a world zip built mid-flight — always deploy from merged HEAD.
+
+### 1. Deploy current HEAD to the live container
+
+```bash
+scripts/motfb-deploy.sh
+```
+
+This replaces `/data/Times_Square__NYC/datapacks/motfb` in the running container
+with the worktree's `output/motfb-datapack`, reloads datapacks, runs `motfb:init`,
+and confirms difficulty is Hard. Exits non-zero on any failure.
+
+### 2. Verify the live container matches HEAD
+
+```bash
+scripts/motfb-verify-deployed.sh
+```
+
+Diffs the live container's deployed datapack against `output/motfb-datapack`. Exits
+0 on a clean match, non-zero with a list of divergent files on mismatch.
+
+### 3. Rebuild the world zip (after all siblings land)
+
+Run this only after **all** sibling sub-issues have merged and CI is green:
+
+```bash
+scripts/motfb-package-world.sh <zip-name>
+# Example:
+scripts/motfb-package-world.sh motfb-phase-d-rev2
+```
+
+Pulls the live world from the container and writes
+`/home/jason/motfb-docs/<zip-name>.zip`, overwriting any existing file.
+
+### Mandatory close sequence for any datapack-touching sub-issue
+
+1. `scripts/motfb-deploy.sh` — push HEAD to container
+2. `scripts/motfb-verify-deployed.sh` — confirm match (must exit 0)
+3. Post completion comment; mark `in_review`
+4. World zip rebuild (`motfb-package-world.sh`) is deferred until all siblings land
+
 ## Troubleshooting
 
 **Script cannot reach docker**: confirm the executing user is in the `docker`

--- a/output/motfb-datapack/pack.mcmeta
+++ b/output/motfb-datapack/pack.mcmeta
@@ -1,6 +1,7 @@
 {
   "pack": {
-    "pack_format": 81,
-    "description": "Mall of the Final Bosses — custom mechanics"
+    "description": "Mall of the Final Bosses — custom mechanics",
+    "min_format": [101, 1],
+    "max_format": 101
   }
 }

--- a/scripts/motfb-deploy.sh
+++ b/scripts/motfb-deploy.sh
@@ -1,0 +1,88 @@
+#!/usr/bin/env bash
+# Push the current branch's datapack to the live minecraft-papermc container
+# and verify difficulty flips to Hard.
+#
+# Usage: motfb-deploy.sh [--help]
+#
+# Source:      output/motfb-datapack  (repo root)
+# Destination: /data/Times_Square__NYC/datapacks/motfb  (in container)
+
+set -euo pipefail
+
+CONTAINER="minecraft-papermc"
+WORLD="Times_Square__NYC"
+DATAPACK_DEST="/data/$WORLD/datapacks/motfb"
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+REPO_ROOT="$(cd "$SCRIPT_DIR/.." && pwd)"
+DATAPACK_SRC="$REPO_ROOT/output/motfb-datapack"
+
+usage() {
+    cat <<'EOF'
+Usage: motfb-deploy.sh [--help]
+
+Deploys the current branch HEAD datapack to the live minecraft-papermc container.
+
+  Source:      <repo>/output/motfb-datapack
+  Destination: /data/Times_Square__NYC/datapacks/motfb  (inside container)
+
+Steps:
+  1. Validates container is running and source datapack exists
+  2. Replaces the live datapack via docker cp
+  3. Reloads datapacks via rcon
+  4. Runs motfb:init and verifies difficulty is Hard
+  5. Exits non-zero on any failure
+
+Exit codes:
+  0  deploy successful; difficulty confirmed Hard
+  1  validation or runtime error
+EOF
+    exit 0
+}
+
+[[ "${1:-}" == "--help" || "${1:-}" == "-h" ]] && usage
+
+if [[ ! -d "$DATAPACK_SRC" ]]; then
+    echo "Error: datapack not found at $DATAPACK_SRC" >&2
+    exit 1
+fi
+
+if ! docker inspect --format='{{.State.Running}}' "$CONTAINER" 2>/dev/null | grep -q "true"; then
+    echo "Error: container '$CONTAINER' is not running" >&2
+    exit 1
+fi
+
+echo "==> Removing existing datapack from container..."
+docker exec "$CONTAINER" rm -rf "$DATAPACK_DEST"
+
+echo "==> Copying $DATAPACK_SRC -> $CONTAINER:$DATAPACK_DEST"
+docker cp "$DATAPACK_SRC" "$CONTAINER:$DATAPACK_DEST"
+
+echo "==> Setting ownership..."
+docker exec "$CONTAINER" chown -R minecraft:minecraft "$DATAPACK_DEST"
+
+echo "==> Reloading datapacks..."
+docker exec "$CONTAINER" rcon-cli reload
+
+echo "==> Running motfb:init..."
+INIT_OUT=$(docker exec "$CONTAINER" rcon-cli "function motfb:init" 2>&1)
+echo "$INIT_OUT"
+if echo "$INIT_OUT" | grep -qiE "(error|unknown function|no function|failed)"; then
+    echo "ERROR: motfb:init reported an error" >&2
+    exit 1
+fi
+
+echo "==> Verifying difficulty is Hard..."
+DIFF_OUT=$(docker exec "$CONTAINER" rcon-cli "difficulty" 2>&1)
+echo "$DIFF_OUT"
+if ! echo "$DIFF_OUT" | grep -qi "hard"; then
+    echo "ERROR: difficulty is not Hard after motfb:init — got: $DIFF_OUT" >&2
+    exit 1
+fi
+
+echo ""
+echo "=== Deploy successful ==="
+echo "  Container:  $CONTAINER"
+echo "  World:      $WORLD"
+echo "  Datapack:   $DATAPACK_DEST"
+echo "  Difficulty: Hard ✓"

--- a/scripts/motfb-package-world.sh
+++ b/scripts/motfb-package-world.sh
@@ -1,0 +1,75 @@
+#!/usr/bin/env bash
+# Rebuild the MOTFB world zip from the live container's current world state.
+#
+# Usage: motfb-package-world.sh <zip-name> [--help]
+#
+# Pulls Times_Square__NYC from the live container and writes
+# /home/jason/motfb-docs/<zip-name>.zip, overwriting any existing file.
+# Run this after motfb-deploy.sh confirms the container matches HEAD.
+
+set -euo pipefail
+
+CONTAINER="minecraft-papermc"
+WORLD="Times_Square__NYC"
+WORLD_IN_CONTAINER="/data/$WORLD"
+MOTFB_DOCS="/home/jason/motfb-docs"
+
+usage() {
+    cat <<'EOF'
+Usage: motfb-package-world.sh <zip-name>
+
+  <zip-name>   Output filename without .zip, e.g. motfb-phase-d-rev2
+
+Pulls the live container world and writes /home/jason/motfb-docs/<zip-name>.zip.
+Run after scripts/motfb-deploy.sh has confirmed the container matches HEAD and
+all sibling sub-issues have merged to the branch.
+
+Exit codes:
+  0  zip written successfully
+  1  validation or runtime error
+EOF
+    exit 0
+}
+
+[[ "${1:-}" == "--help" || "${1:-}" == "-h" ]] && usage
+
+if [[ $# -lt 1 ]]; then
+    echo "Error: missing <zip-name>" >&2
+    echo "Run '$0 --help' for usage." >&2
+    exit 1
+fi
+
+ZIP_NAME="$1"
+
+if [[ "$ZIP_NAME" == *".."* || "$ZIP_NAME" == *"/"* ]]; then
+    echo "Error: zip name contains invalid characters: $ZIP_NAME" >&2
+    exit 1
+fi
+
+OUTPUT_ZIP="$MOTFB_DOCS/${ZIP_NAME}.zip"
+
+if ! docker inspect --format='{{.State.Running}}' "$CONTAINER" 2>/dev/null | grep -q "true"; then
+    echo "Error: container '$CONTAINER' is not running" >&2
+    exit 1
+fi
+
+if [[ ! -d "$MOTFB_DOCS" ]]; then
+    echo "Error: motfb-docs directory not found: $MOTFB_DOCS" >&2
+    exit 1
+fi
+
+TMPDIR_WORLD=$(mktemp -d)
+trap 'rm -rf "$TMPDIR_WORLD"' EXIT
+
+echo "==> Pulling world from $CONTAINER:$WORLD_IN_CONTAINER..."
+docker cp "$CONTAINER:$WORLD_IN_CONTAINER" "$TMPDIR_WORLD/$WORLD"
+
+echo "==> Building zip: $OUTPUT_ZIP..."
+rm -f "$OUTPUT_ZIP"
+(cd "$TMPDIR_WORLD" && zip -r "$OUTPUT_ZIP" "$WORLD" -x "*.lock" -x "session.lock")
+
+echo ""
+echo "=== Package complete ==="
+echo "  World:  $WORLD"
+echo "  Output: $OUTPUT_ZIP"
+echo "  Size:   $(du -sh "$OUTPUT_ZIP" | cut -f1)"

--- a/scripts/motfb-verify-deployed.sh
+++ b/scripts/motfb-verify-deployed.sh
@@ -1,0 +1,73 @@
+#!/usr/bin/env bash
+# Verify the live container's deployed datapack matches the current branch HEAD.
+#
+# Usage: motfb-verify-deployed.sh [--help]
+#
+# Diffs the live container's /data/Times_Square__NYC/datapacks/motfb against
+# output/motfb-datapack in the current worktree. Exits non-zero and names any
+# divergent files on mismatch.
+
+set -euo pipefail
+
+CONTAINER="minecraft-papermc"
+WORLD="Times_Square__NYC"
+DATAPACK_IN_CONTAINER="/data/$WORLD/datapacks/motfb"
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+REPO_ROOT="$(cd "$SCRIPT_DIR/.." && pwd)"
+DATAPACK_SRC="$REPO_ROOT/output/motfb-datapack"
+
+usage() {
+    cat <<'EOF'
+Usage: motfb-verify-deployed.sh [--help]
+
+Checks that the live container's deployed datapack matches the current branch HEAD.
+
+  HEAD source: <repo>/output/motfb-datapack
+  Live source: /data/Times_Square__NYC/datapacks/motfb  (inside container)
+
+Exit codes:
+  0  live container matches HEAD exactly
+  1  mismatch or infrastructure error; divergent files printed to stderr
+EOF
+    exit 0
+}
+
+[[ "${1:-}" == "--help" || "${1:-}" == "-h" ]] && usage
+
+if [[ ! -d "$DATAPACK_SRC" ]]; then
+    echo "Error: local datapack not found at $DATAPACK_SRC" >&2
+    exit 1
+fi
+
+if ! docker inspect --format='{{.State.Running}}' "$CONTAINER" 2>/dev/null | grep -q "true"; then
+    echo "Error: container '$CONTAINER' is not running" >&2
+    exit 1
+fi
+
+TMPDIR_VERIFY=$(mktemp -d)
+trap 'rm -rf "$TMPDIR_VERIFY"' EXIT
+
+echo "==> Pulling deployed datapack from $CONTAINER:$DATAPACK_IN_CONTAINER..."
+docker cp "$CONTAINER:$DATAPACK_IN_CONTAINER" "$TMPDIR_VERIFY/motfb"
+
+echo "==> Diffing live container against local HEAD..."
+DIFF_EXIT=0
+DIFF_DETAIL=$(diff -r "$DATAPACK_SRC" "$TMPDIR_VERIFY/motfb" 2>&1) || DIFF_EXIT=$?
+
+if [[ $DIFF_EXIT -ne 0 ]]; then
+    echo ""
+    echo "ERROR: Live container datapack does NOT match HEAD." >&2
+    echo "Run scripts/motfb-deploy.sh to sync." >&2
+    echo ""
+    echo "Divergent files:" >&2
+    diff -rq "$DATAPACK_SRC" "$TMPDIR_VERIFY/motfb" 2>&1 \
+        | sed "s|$DATAPACK_SRC|HEAD|g; s|$TMPDIR_VERIFY/motfb|LIVE|g" >&2
+    exit 1
+fi
+
+echo ""
+echo "=== Verification passed ==="
+echo "  Live container matches HEAD"
+echo "  HEAD:  $DATAPACK_SRC"
+echo "  Live:  $CONTAINER:$DATAPACK_IN_CONTAINER"


### PR DESCRIPTION
Resolves [MIN-168](https://cirruslycloudy.com/MIN/issues/MIN-168)

## Changes

**Resource pack (`/home/jason/motfb-docs/resourcepack-motfb-rough.zip`)**
- Rebuilt zip from inside `resourcepack-motfb-rough/` so `pack.mcmeta` is at the zip root (no wrapper directory). Fix: `cd resourcepack-motfb-rough && zip -r ../foo.zip .`
- Migrated `pack.mcmeta` from legacy `pack_format: 84` to `min_format: [84, 0], max_format: 84` (required for MC ≥ 1.20.5 / pack_format > 64)

**Datapack (`output/motfb-datapack/pack.mcmeta`)**
- Updated from `pack_format: 81` (wrong number, legacy schema) to `min_format: [101, 1], max_format: 101` — matching `data_major: 101, data_minor: 1` from `26.1.2.jar → version.json`

Also cherry-picks the `motfb-deploy.sh` / `motfb-verify-deployed.sh` scripts from `feat/min-165` (not yet on main) so the mandatory close sequence runs.

## Verification

- `motfb-deploy.sh` → "Deploy successful, difficulty Hard ✓"
- `motfb-verify-deployed.sh` → "Live container matches HEAD"
- `motfb-smoke.sh output/motfb-datapack motfb:init` → 0 WARN/ERROR, 1 function invoked, 0 errors