### PR TITLE
MIN-172: fix sign NBT — migrate JSON strings to compound format

### DIFF
--- a/output/motfb-datapack/data/motfb/function/build/f1_decor.mcfunction
+++ b/output/motfb-datapack/data/motfb/function/build/f1_decor.mcfunction
@@ -395,7 +395,8 @@ setblock 28 67 -149 minecraft:smooth_stone
 # "FOOD COURT" sign above the orange-concrete entry arch at z=-126
 # Backing block on south face of arch at y=71 (arch is orange concrete at y=65..70)
 setblock 0 71 -126 minecraft:orange_concrete
-setblock 0 71 -125 minecraft:oak_wall_sign[facing=south]{front_text:{messages:['{"text":"FOOD COURT","color":"gold","bold":true}','{"text":"Seating this level","color":"yellow","italic":true}','{"text":""}','{"text":""}'],has_glowing_text:1b,color:"gold"},is_waxed:1b}
+setblock 0 71 -125 minecraft:oak_wall_sign[facing=south]
+data merge block 0 71 -125 {front_text:{messages:[{text:"FOOD COURT",color:"gold",bold:1b},{text:"Seating this level",color:"yellow",italic:1b},{text:""},{text:""}],has_glowing_text:1b,color:"orange"},is_waxed:1b}
 
 # =============================================================================
 # LOBBY MALL DIRECTORY — near south lobby entrance so players know what's here
@@ -403,7 +404,9 @@ setblock 0 71 -125 minecraft:oak_wall_sign[facing=south]{front_text:{messages:['
 # =============================================================================
 
 # West wall directory (visible to players looking toward west wall)
-setblock -6 71 -110 minecraft:oak_wall_sign[facing=east]{front_text:{messages:['{"text":"LIMINAL LAKES MALL","color":"gold","bold":true}','{"text":"West: Hot-Topical","color":"dark_purple"}','{"text":"Cinnabog  GameZone","color":"yellow"}','{"text":"Cluck-O-Mart  SEARZ","color":"red"}'],has_glowing_text:1b,color:"gold"},is_waxed:1b}
+setblock -6 71 -110 minecraft:oak_wall_sign[facing=east]
+data merge block -6 71 -110 {front_text:{messages:[{text:"LIMINAL LAKES MALL",color:"gold",bold:1b},{text:"West: Hot-Topical",color:"dark_purple"},{text:"Cinnabog  GameZone",color:"yellow"},{text:"Cluck-O-Mart  SEARZ",color:"red"}],has_glowing_text:1b,color:"orange"},is_waxed:1b}
 
 # East wall directory (visible to players looking toward east wall)
-setblock 6 71 -110 minecraft:oak_wall_sign[facing=west]{front_text:{messages:['{"text":"LIMINAL LAKES MALL","color":"gold","bold":true}','{"text":"East: Spencers Gifts","color":"orange"}','{"text":"Bath+Body  Pretzel","color":"white"}','{"text":"Spunkys Shoes  SEARZ","color":"aqua"}'],has_glowing_text:1b,color:"gold"},is_waxed:1b}
+setblock 6 71 -110 minecraft:oak_wall_sign[facing=west]
+data merge block 6 71 -110 {front_text:{messages:[{text:"LIMINAL LAKES MALL",color:"gold",bold:1b},{text:"East: Spencers Gifts",color:"orange"},{text:"Bath+Body  Pretzel",color:"white"},{text:"Spunkys Shoes  SEARZ",color:"aqua"}],has_glowing_text:1b,color:"orange"},is_waxed:1b}

--- a/output/motfb-datapack/data/motfb/function/build/scene_details.mcfunction
+++ b/output/motfb-datapack/data/motfb/function/build/scene_details.mcfunction
@@ -192,48 +192,59 @@ tellraw @a {"text":"[MOTFB] Store entry end rods, corridor columns, and wall bas
 
 # Hot-Topical (midpoint z=-193)
 fill -7 70 -193 -7 70 -193 minecraft:black_concrete replace minecraft:air
-setblock -6 70 -193 minecraft:oak_wall_sign[facing=east]{front_text:{messages:['{"text":"HOT-TOPICAL","color":"dark_purple","bold":true}','{"text":"alt fashion","color":"light_purple","italic":true}','{"text":""}','{"text":""}'],has_glowing_text:1b,color:"dark_purple"},is_waxed:1b}
+setblock -6 70 -193 minecraft:oak_wall_sign[facing=east]
+data merge block -6 70 -193 {front_text:{messages:[{text:"HOT-TOPICAL",color:"dark_purple",bold:1b},{text:"alt fashion",color:"light_purple",italic:1b},{text:""},{text:""}],has_glowing_text:1b,color:"purple"},is_waxed:1b}
 
 # Build-A-Boss (midpoint z=-208)
 fill -7 70 -208 -7 70 -208 minecraft:pink_concrete replace minecraft:air
-setblock -6 70 -208 minecraft:oak_wall_sign[facing=east]{front_text:{messages:['{"text":"BUILD-A-BOSS","color":"light_purple","bold":true}','{"text":"custom creatures","color":"pink","italic":true}','{"text":""}','{"text":""}'],has_glowing_text:1b,color:"light_purple"},is_waxed:1b}
+setblock -6 70 -208 minecraft:oak_wall_sign[facing=east]
+data merge block -6 70 -208 {front_text:{messages:[{text:"BUILD-A-BOSS",color:"light_purple",bold:1b},{text:"custom creatures",color:"light_purple",italic:1b},{text:""},{text:""}],has_glowing_text:1b,color:"pink"},is_waxed:1b}
 
 # Cinnabog (midpoint z=-223)
 fill -7 70 -223 -7 70 -223 minecraft:orange_concrete replace minecraft:air
-setblock -6 70 -223 minecraft:oak_wall_sign[facing=east]{front_text:{messages:['{"text":"CINNABOG","color":"yellow","bold":true}','{"text":"fresh baked horrors","color":"gold","italic":true}','{"text":""}','{"text":""}'],has_glowing_text:1b,color:"yellow"},is_waxed:1b}
+setblock -6 70 -223 minecraft:oak_wall_sign[facing=east]
+data merge block -6 70 -223 {front_text:{messages:[{text:"CINNABOG",color:"yellow",bold:1b},{text:"fresh baked horrors",color:"gold",italic:1b},{text:""},{text:""}],has_glowing_text:1b,color:"yellow"},is_waxed:1b}
 
 # GameZone / ARCADE — also serves as Lost Kid directional sign (midpoint z=-238)
 fill -7 70 -238 -7 70 -238 minecraft:dark_oak_planks replace minecraft:air
-setblock -6 70 -238 minecraft:oak_wall_sign[facing=east]{front_text:{messages:['{"text":"GAMEZONE / ARCADE","color":"dark_green","bold":true}','{"text":"→ Enter for The Lost Kid","color":"gold"}','{"text":"  (find them inside)","color":"gray","italic":true}','{"text":""}'],has_glowing_text:1b,color:"dark_green"},is_waxed:1b}
+setblock -6 70 -238 minecraft:oak_wall_sign[facing=east]
+data merge block -6 70 -238 {front_text:{messages:[{text:"GAMEZONE / ARCADE",color:"dark_green",bold:1b},{text:"→ Enter for The Lost Kid",color:"gold"},{text:"  (find them inside)",color:"gray",italic:1b},{text:""}],has_glowing_text:1b,color:"green"},is_waxed:1b}
 
 # Cluck-O-Mart (midpoint z=-253)
 fill -7 70 -253 -7 70 -253 minecraft:red_concrete replace minecraft:air
-setblock -6 70 -253 minecraft:oak_wall_sign[facing=east]{front_text:{messages:['{"text":"CLUCK-O-MART","color":"red","bold":true}','{"text":"drive-thru inside","color":"yellow","italic":true}','{"text":""}','{"text":""}'],has_glowing_text:1b,color:"red"},is_waxed:1b}
+setblock -6 70 -253 minecraft:oak_wall_sign[facing=east]
+data merge block -6 70 -253 {front_text:{messages:[{text:"CLUCK-O-MART",color:"red",bold:1b},{text:"drive-thru inside",color:"yellow",italic:1b},{text:""},{text:""}],has_glowing_text:1b,color:"red"},is_waxed:1b}
 
 # SEARZ (full-width anchor, visible both sides)
 fill -7 70 -270 -7 70 -270 minecraft:smooth_quartz replace minecraft:air
-setblock -6 70 -270 minecraft:oak_wall_sign[facing=east]{front_text:{messages:['{"text":"SEARZ","color":"dark_red","bold":true}','{"text":"DEPT STORE","color":"red"}','{"text":""}','{"text":""}'],has_glowing_text:1b,color:"dark_red"},is_waxed:1b}
+setblock -6 70 -270 minecraft:oak_wall_sign[facing=east]
+data merge block -6 70 -270 {front_text:{messages:[{text:"SEARZ",color:"dark_red",bold:1b},{text:"DEPT STORE",color:"red"},{text:""},{text:""}],has_glowing_text:1b,color:"red"},is_waxed:1b}
 
 # --- East side store signs (facing=west) ---
 
 # Spencers Cursed Gifts (midpoint z=-253)
 fill 7 70 -253 7 70 -253 minecraft:orange_concrete replace minecraft:air
-setblock 6 70 -253 minecraft:oak_wall_sign[facing=west]{front_text:{messages:['{"text":"SPENCERS GIFTS","color":"orange","bold":true}','{"text":"cursed collectibles","color":"yellow","italic":true}','{"text":""}','{"text":""}'],has_glowing_text:1b,color:"orange"},is_waxed:1b}
+setblock 6 70 -253 minecraft:oak_wall_sign[facing=west]
+data merge block 6 70 -253 {front_text:{messages:[{text:"SPENCERS GIFTS",color:"orange",bold:1b},{text:"cursed collectibles",color:"yellow",italic:1b},{text:""},{text:""}],has_glowing_text:1b,color:"orange"},is_waxed:1b}
 
 # Bath and Bodywork Sanctum (midpoint z=-238)
 fill 7 70 -238 7 70 -238 minecraft:white_concrete replace minecraft:air
-setblock 6 70 -238 minecraft:oak_wall_sign[facing=west]{front_text:{messages:['{"text":"BATH + BODY","color":"white","bold":true}','{"text":"sanctum of scents","color":"light_purple","italic":true}','{"text":""}','{"text":""}'],has_glowing_text:1b,color:"white"},is_waxed:1b}
+setblock 6 70 -238 minecraft:oak_wall_sign[facing=west]
+data merge block 6 70 -238 {front_text:{messages:[{text:"BATH + BODY",color:"white",bold:1b},{text:"sanctum of scents",color:"light_purple",italic:1b},{text:""},{text:""}],has_glowing_text:1b,color:"white"},is_waxed:1b}
 
 # Pretzel-Pretzel Pretzel (midpoint z=-223)
 fill 7 70 -223 7 70 -223 minecraft:smooth_sandstone replace minecraft:air
-setblock 6 70 -223 minecraft:oak_wall_sign[facing=west]{front_text:{messages:['{"text":"PRETZEL HUT","color":"gold","bold":true}','{"text":"infinite knots","color":"yellow","italic":true}','{"text":""}','{"text":""}'],has_glowing_text:1b,color:"gold"},is_waxed:1b}
+setblock 6 70 -223 minecraft:oak_wall_sign[facing=west]
+data merge block 6 70 -223 {front_text:{messages:[{text:"PRETZEL HUT",color:"gold",bold:1b},{text:"infinite knots",color:"yellow",italic:1b},{text:""},{text:""}],has_glowing_text:1b,color:"orange"},is_waxed:1b}
 
 # Spunkys Footwear (midpoint z=-208)
 fill 7 70 -208 7 70 -208 minecraft:white_concrete replace minecraft:air
-setblock 6 70 -208 minecraft:oak_wall_sign[facing=west]{front_text:{messages:['{"text":"SPUNKYS SHOES","color":"aqua","bold":true}','{"text":"run while you can","color":"white","italic":true}','{"text":""}','{"text":""}'],has_glowing_text:1b,color:"aqua"},is_waxed:1b}
+setblock 6 70 -208 minecraft:oak_wall_sign[facing=west]
+data merge block 6 70 -208 {front_text:{messages:[{text:"SPUNKYS SHOES",color:"aqua",bold:1b},{text:"run while you can",color:"white",italic:1b},{text:""},{text:""}],has_glowing_text:1b,color:"cyan"},is_waxed:1b}
 
 # SEARZ east side (mirror of west)
 fill 7 70 -270 7 70 -270 minecraft:smooth_quartz replace minecraft:air
-setblock 6 70 -270 minecraft:oak_wall_sign[facing=west]{front_text:{messages:['{"text":"SEARZ","color":"dark_red","bold":true}','{"text":"DEPT STORE","color":"red"}','{"text":""}','{"text":""}'],has_glowing_text:1b,color:"dark_red"},is_waxed:1b}
+setblock 6 70 -270 minecraft:oak_wall_sign[facing=west]
+data merge block 6 70 -270 {front_text:{messages:[{text:"SEARZ",color:"dark_red",bold:1b},{text:"DEPT STORE",color:"red"},{text:""},{text:""}],has_glowing_text:1b,color:"red"},is_waxed:1b}
 
 tellraw @a {"text":"[MOTFB] Store name signs placed at all 10 entrances.","color":"aqua"}

--- a/output/motfb-datapack/data/motfb/function/build/setup_journals.mcfunction
+++ b/output/motfb-datapack/data/motfb/function/build/setup_journals.mcfunction
@@ -10,7 +10,8 @@ setblock 0 66 -134 minecraft:oak_log[axis=y]
 setblock 0 67 -134 minecraft:lectern[facing=south]
 setblock 0 68 -134 minecraft:end_rod[facing=up]
 setblock 0 69 -134 minecraft:sea_lantern
-setblock -1 67 -134 minecraft:oak_wall_sign[facing=east]{front_text:{messages:['{"text":"JOURNAL","color":"gold","bold":true}','{"text":"\"...they opened late,","color":"white"}','{"text":"they opened always...\"","color":"white"}','{"text":"[Approach to read]","color":"gray","italic":true}'],has_glowing_text:1b,color:"black"},is_waxed:1b}
+setblock -1 67 -134 minecraft:oak_wall_sign[facing=east]
+data merge block -1 67 -134 {front_text:{messages:[{text:"JOURNAL",color:"gold",bold:1b},{text:"\"...they opened late,",color:"white"},{text:"they opened always...\"",color:"white"},{text:"[Approach to read]",color:"gray",italic:1b}],has_glowing_text:1b,color:"black"},is_waxed:1b}
 
 # Journal 2 — Inside SEARZ (z=-272): found after Mama SEARZ is defeated
 setblock 0 69 -272 minecraft:oak_log[axis=y]
@@ -18,11 +19,13 @@ setblock 0 70 -272 minecraft:oak_log[axis=y]
 setblock 0 71 -272 minecraft:lectern[facing=south]
 setblock 0 72 -272 minecraft:end_rod[facing=up]
 setblock 0 73 -272 minecraft:sea_lantern
-setblock -1 71 -272 minecraft:oak_wall_sign[facing=east]{front_text:{messages:['{"text":"JOURNAL","color":"gold","bold":true}','{"text":"\"Clearance on all","color":"white"}','{"text":"warranties. All of them.\"","color":"white"}','{"text":"[Approach to read]","color":"gray","italic":true}'],has_glowing_text:1b,color:"black"},is_waxed:1b}
+setblock -1 71 -272 minecraft:oak_wall_sign[facing=east]
+data merge block -1 71 -272 {front_text:{messages:[{text:"JOURNAL",color:"gold",bold:1b},{text:"\"Clearance on all",color:"white"},{text:"warranties. All of them.\"",color:"white"},{text:"[Approach to read]",color:"gray",italic:1b}],has_glowing_text:1b,color:"black"},is_waxed:1b}
 
 # Journal 3 — Office antechamber (y=98, z=-218): discovered before meeting Bryan
 setblock -5 98 -218 minecraft:oak_log[axis=y]
 setblock -5 99 -218 minecraft:lectern[facing=east]
 setblock -5 100 -218 minecraft:end_rod[facing=up]
 setblock -5 101 -218 minecraft:sea_lantern
-setblock -6 99 -218 minecraft:oak_wall_sign[facing=east]{front_text:{messages:['{"text":"JOURNAL","color":"gold","bold":true}','{"text":"\"Per the Original","color":"white"}','{"text":"Contract, §7.4...\"","color":"white"}','{"text":"[Approach to read]","color":"gray","italic":true}'],has_glowing_text:1b,color:"black"},is_waxed:1b}
+setblock -6 99 -218 minecraft:oak_wall_sign[facing=east]
+data merge block -6 99 -218 {front_text:{messages:[{text:"JOURNAL",color:"gold",bold:1b},{text:"\"Per the Original",color:"white"},{text:"Contract, §7.4...\"",color:"white"},{text:"[Approach to read]",color:"gray",italic:1b}],has_glowing_text:1b,color:"black"},is_waxed:1b}

--- a/output/motfb-datapack/data/motfb/function/lostkid/spawn_at_arcade.mcfunction
+++ b/output/motfb-datapack/data/motfb/function/lostkid/spawn_at_arcade.mcfunction
@@ -2,4 +2,5 @@ kill @e[tag=motfb_lostkid]
 summon villager -30 65 -238 {Tags:["motfb_lostkid"],CustomName:'{"text":"The Lost Kid","color":"yellow","italic":false}',CustomNameVisible:1b,VillagerData:{type:"plains",profession:"none",level:1},NoAI:0b,Silent:1b,Invulnerable:1b,PersistenceRequired:1b,Health:20.0f,Attributes:[{Name:"minecraft:movement_speed",Base:0.5},{Name:"minecraft:follow_range",Base:64}]}
 
 # directional sign on concourse wall (x=-6, facing the corridor)
-setblock -6 67 -238 minecraft:oak_wall_sign[facing=west]{front_text:{messages:['{"text":"THE LOST KID","color":"yellow","bold":true}','{"text":"is in the Arcade >>","color":"white"}','{"text":"Give a Mall Pretzel","color":"gold"}','{"text":"to recruit them.","color":"gold"}'],has_glowing_text:1b,color:"black"},is_waxed:1b}
+setblock -6 67 -238 minecraft:oak_wall_sign[facing=west]
+data merge block -6 67 -238 {front_text:{messages:[{text:"THE LOST KID",color:"yellow",bold:1b},{text:"is in the Arcade >>",color:"white"},{text:"Give a Mall Pretzel",color:"gold"},{text:"to recruit them.",color:"gold"}],has_glowing_text:1b,color:"black"},is_waxed:1b}


### PR DESCRIPTION
Resolves [MIN-172](https://cirruslycloudy.com/MIN/issues/MIN-172)

## Root cause

Minecraft 1.26.x changed sign `front_text.messages` storage from `TAG_String` containing serialised JSON (`'{"text":"FOOD COURT"}'`) to native `TAG_Compound` text components (`{text:"FOOD COURT",color:"gold",bold:1b}`). The old JSON-string format was accepted and stored by the server, but rendered as literal text rather than parsed components — producing the raw `{"text":"..."` display the owner reported.

## Changes

- **`build/scene_details.mcfunction`** — 10 store-name signs migrated to two-step `setblock` + `data merge block` with compound messages; `front_text.color` corrected to valid dye names (`dark_purple→purple`, `gold→orange`, `dark_red→red`, `dark_green→green`, `light_purple→pink`, `aqua→cyan`)
- **`build/f1_decor.mcfunction`** — 3 signs (FOOD COURT + 2 lobby directories) same migration
- **`build/setup_journals.mcfunction`** — 3 journal marker signs same migration
- **`lostkid/spawn_at_arcade.mcfunction`** — 1 directional sign same migration

## Verified

- `data get block` on live 1.26.1.2 server confirms messages stored as `{bold: 1b, color: "dark_purple", text: "HOT-TOPICAL"}` (compound, not string)
- Smoke test: 0 WARN/ERROR, `motfb:init` exercised cleanly

## Base branch

Branched from `feat/min-167` (this fix layers on top of the Phase D mall structure).