### PR TITLE
fix: broaden CI trigger paths — unblock CLAUDE.md and output/** PRs (MIN-184)

### DIFF
--- a/.github/workflows/ci-build.yml
+++ b/.github/workflows/ci-build.yml
@@ -13,6 +13,9 @@ on:
       - 'docs/**'
       - 'marketing/**'
       - 'README.md'
+      - 'CLAUDE.md'
+      - 'output/**'
+      - 'scripts/**'
   push:
     branches:
       - main


### PR DESCRIPTION
## Problem

Branch protection on `main` now requires 8 CI status checks to pass before merge. PRs that only touch `CLAUDE.md`, `output/motfb-datapack/`, or `scripts/` do not match the existing `pull_request.paths` filter — CI never runs on them, so required checks are permanently unresolvable.

Blocked PRs: #86 (CLAUDE.md), #87 and #91 (output/motfb-datapack/).

## Fix

Add three path groups to the `pull_request` trigger:
- `CLAUDE.md` — project instructions change frequently via agent loop
- `output/**` — mcfunction datapack files (PRs #87, #91)
- `scripts/**` — smoke/selftest scripts, also agent-touched frequently

## Verification

This PR itself touches `.github/**` so CI will run normally. After merge, re-triggering CI on #86/#87/#91 (via a no-op push or `gh workflow run`) will produce the required check results.

Resolves [MIN-184](/MIN/issues/MIN-184)