### PR TITLE
fix: remove stale difficulty normal from f2_lighting (MIN-194)

### DIFF
--- a/output/motfb-datapack/data/motfb/function/build/f2_lighting.mcfunction
+++ b/output/motfb-datapack/data/motfb/function/build/f2_lighting.mcfunction
@@ -124,5 +124,3 @@ fill -49 96 -117 49 96 -117 minecraft:sea_lantern
 fill -49 96 -111 49 96 -111 minecraft:sea_lantern
 fill -49 96 -105 49 96 -105 minecraft:sea_lantern
 
-# --- Reset difficulty if Jason had overridden it ---
-difficulty normal


### PR DESCRIPTION
## Problem

`f2_lighting.mcfunction` ends with:

```
# --- Reset difficulty if Jason had overridden it ---
difficulty normal
```

`motfb:init` sets `difficulty hard` at line 2, then calls `build/all → visual_rev1 → f2_lighting`, which immediately overrides it back to Normal. This caused the MIN-194 deploy to fail the difficulty guard.

## Fix

Remove the two stale lines. Difficulty management belongs in `init.mcfunction` and `reset.mcfunction` only.

## Test

Deploy guard now passes: `motfb-deploy.sh --ref <this branch>` exits 0.