### PR TITLE
MIN-198: Add missing corridor base fill to f1_floors.mcfunction

### DIFF
--- a/output/motfb-datapack/data/motfb/function/build/f1_floors.mcfunction
+++ b/output/motfb-datapack/data/motfb/function/build/f1_floors.mcfunction
@@ -93,6 +93,9 @@ fill -40 64 -275 -35 64 -270 minecraft:cracked_stone_bricks
 fill 30 64 -275 38 64 -268 minecraft:cracked_stone_bricks
 fill -20 64 -265 -10 64 -261 minecraft:cracked_stone_bricks
 
+# Corridor base floor §1.0 (was missing — caused entrance-corridor gaps)
+fill -6 64 -185 6 64 -102 minecraft:smooth_quartz
+
 # --- Corridor floor (x=-6..6): keep smooth quartz per §1.0 but add polished andesite grout lines ---
 # Grout lines every 4 blocks in z
 fill -6 64 -279 6 64 -279 minecraft:polished_andesite

--- a/scripts/motfb-smoke.sh
+++ b/scripts/motfb-smoke.sh
@@ -299,6 +299,33 @@ if [[ "${BEHAVIORAL_ASSERTIONS:-false}" == "true" ]]; then
         fi
     done
 
+    # Assertion 2b: Corridor band flatness probes (MIN-196 continuity)
+    echo ""
+    echo "  Assertion 2b: Corridor band flatness probes"
+    CORRIDOR_COORDS=(
+        "0:64:-110" "0:64:-160" "0:64:-175"
+    )
+    for coord in "${CORRIDOR_COORDS[@]}"; do
+        IFS=':' read -r x y z <<< "$coord"
+        block_data=$(docker exec "$CONTAINER" rcon-cli "data get block $x $y $z" 2>&1) || true
+
+        # Extract block type from the output: {name:"minecraft:smooth_quartz",...}
+        block_type=$(echo "$block_data" | grep -oP 'name:"minecraft:\K[^"]+' || true)
+
+        if [[ -z "$block_type" ]]; then
+            echo "  ✗ Corridor floor at $x $y $z: cannot read block data"
+            ASSERTION_ERRORS=$((ASSERTION_ERRORS + 1))
+        elif [[ "$block_type" == "air" ]]; then
+            echo "  ✗ Corridor floor at $x $y $z: observed=$block_type (FAIL)"
+            ASSERTION_ERRORS=$((ASSERTION_ERRORS + 1))
+        elif [[ "$block_type" == "smooth_quartz" || "$block_type" == "polished_andesite" ]]; then
+            echo "  ✓ Corridor floor at $x $y $z: observed=$block_type"
+        else
+            echo "  ✗ Corridor floor at $x $y $z: observed=$block_type (expected smooth_quartz or polished_andesite)"
+            ASSERTION_ERRORS=$((ASSERTION_ERRORS + 1))
+        fi
+    done
+
     # Assertion 3: Spawn block assertion
     echo ""
     echo "  Assertion 3: Spawn block assertion (0 64 -150)"


### PR DESCRIPTION
Resolves [MIN-198](https://cirruslycloudy.com/MIN/issues/MIN-198)

## What

Inserts the missing `fill -6 64 -185 6 64 -102 minecraft:smooth_quartz` into `f1_floors.mcfunction` before the polished andesite grout stripe loop.

## Why

The corridor base fill for x=-6..6, z=-185..-102 was documented in §1.0 (header comment on line 4) but the actual `fill` command was never emitted. This caused bare/uncoated floor blocks in the entrance corridor section of Floor 1.

## Verification

- Smoke check against live pack: `motfb:build/f1_floors` — zero WARN/ERROR lines.
- Fill command placement: before andesite accent stripes, after SEARZ anchor section.