### PR TITLE
MIN-204: fix smoke probe false positives for non-block-entity solid blocks

### DIFF
--- a/scripts/motfb-smoke.sh
+++ b/scripts/motfb-smoke.sh
@@ -244,8 +244,9 @@ assert_entity_exists() {
 assert_no_legacy_sign() {
     local x=$1 y=$2 z=$3
     local result=$(docker exec "$CONTAINER" rcon-cli "data get block $x $y $z Text1" 2>&1) || true
-    if echo "$result" | grep -qiE "(error|no such|cannot find|no elements matching)" || [[ -z "$result" ]]; then
-        # Modern format - Text1 does not exist
+    # "not a block entity" means the block is not a sign at all — pass (no legacy data)
+    if echo "$result" | grep -qiE "(error|no such|cannot find|no elements matching|not a block entity)" || [[ -z "$result" ]]; then
+        # Modern format or not a block entity - Text1 does not exist
         return 0
     else
         # Legacy format detected
@@ -307,21 +308,20 @@ if [[ "${BEHAVIORAL_ASSERTIONS:-false}" == "true" ]]; then
     )
     for coord in "${CORRIDOR_COORDS[@]}"; do
         IFS=':' read -r x y z <<< "$coord"
-        block_data=$(docker exec "$CONTAINER" rcon-cli "data get block $x $y $z" 2>&1) || true
+        # Use execute-if-block for solid non-entity blocks; data get block returns
+        # "not a block entity" for these and has no parseable name field.
+        sq_result=$(docker exec "$CONTAINER" rcon-cli "execute if block $x $y $z minecraft:smooth_quartz" 2>&1) || true
+        pa_result=$(docker exec "$CONTAINER" rcon-cli "execute if block $x $y $z minecraft:polished_andesite" 2>&1) || true
 
-        # Extract block type from the output: {name:"minecraft:smooth_quartz",...}
-        block_type=$(echo "$block_data" | grep -oP 'name:"minecraft:\K[^"]+' || true)
-
-        if [[ -z "$block_type" ]]; then
-            echo "  ✗ Corridor floor at $x $y $z: cannot read block data"
+        if echo "$sq_result" | grep -qi "Test passed"; then
+            echo "  ✓ Corridor floor at $x $y $z: smooth_quartz"
+        elif echo "$pa_result" | grep -qi "Test passed"; then
+            echo "  ✓ Corridor floor at $x $y $z: polished_andesite"
+        elif echo "$sq_result" | grep -qi "Test failed" || echo "$pa_result" | grep -qi "Test failed"; then
+            echo "  ✗ Corridor floor at $x $y $z: not smooth_quartz or polished_andesite (FAIL)"
             ASSERTION_ERRORS=$((ASSERTION_ERRORS + 1))
-        elif [[ "$block_type" == "air" ]]; then
-            echo "  ✗ Corridor floor at $x $y $z: observed=$block_type (FAIL)"
-            ASSERTION_ERRORS=$((ASSERTION_ERRORS + 1))
-        elif [[ "$block_type" == "smooth_quartz" || "$block_type" == "polished_andesite" ]]; then
-            echo "  ✓ Corridor floor at $x $y $z: observed=$block_type"
         else
-            echo "  ✗ Corridor floor at $x $y $z: observed=$block_type (expected smooth_quartz or polished_andesite)"
+            echo "  ✗ Corridor floor at $x $y $z: cannot read block data"
             ASSERTION_ERRORS=$((ASSERTION_ERRORS + 1))
         fi
     done


### PR DESCRIPTION
Resolves [MIN-204](https://cirruslycloudy.com/MIN/issues/MIN-204)

## What failed

Running `motfb-smoke.sh --behavioral` against the freshly-deployed `origin/main` produced 14 assertion errors, all false positives from two probe logic bugs introduced in the probe code that landed via MIN-208 (#98):

### Bug 1 — `assert_no_legacy_sign` false positives (11 errors)

`data get block $x $y $z Text1` on a non-block-entity block (air, quartz, etc.) returns
`"The target block is not a block entity"`. The pass-pattern grep did not include this
phrase, so every non-sign block at a sign coordinate was flagged as a legacy-schema sign.

**Fix**: add `"not a block entity"` to the pass patterns in `assert_no_legacy_sign`.

### Bug 2 — Corridor floor probe false negatives (3 errors)

Assertion 2b used `data get block $x $y $z` and grepped for `name:"minecraft:..."`.
That pattern never appears for solid non-entity blocks — they return `"The target block is not a block entity"` — so all three corridor probes reported `"cannot read block data"` even though the blocks were confirmed present via RCON (`execute if block` → Test passed).

**Fix**: replace the `data get block` + grep approach with two `execute if block` calls
(smooth_quartz, polished_andesite), matching how Assertion 2 works.

## Verified

After fixes, `motfb-smoke.sh --behavioral output/motfb-datapack` exits 0 with 0 assertion errors against the live container running `origin/main` (`e1b59f7`).

Deploy + verify pipeline results:
- `motfb-deploy.sh --ref origin/main` → exit 0, difficulty Hard ✓
- `motfb-verify-deployed.sh --ref origin/main` → exit 0, live matches e1b59f7 ✓
- `motfb-smoke.sh --behavioral` (post-fix) → exit 0, 0 errors ✓