### PR TITLE
MIN-233: Fix outer wall chunk-load gap — forceload guards for Steps B/C

### DIFF
--- a/output/motfb-datapack/data/motfb/function/build/f1_sprawl.mcfunction
+++ b/output/motfb-datapack/data/motfb/function/build/f1_sprawl.mcfunction
@@ -300,7 +300,10 @@ fill -86 79 -107 -51 79 -107 minecraft:sea_lantern
 fill -86 79 -103 -51 79 -103 minecraft:sea_lantern
 
 # New outer west wall: white concrete, z=-100..-280, y=59..82 (roof parapet height)
+# forceload ensures z≈-195..-280 chunks are loaded; narrow single-column fills silently skip unloaded chunks
+forceload add -96 -288 96 -96
 fill -86 59 -280 -86 82 -100 minecraft:white_concrete
+forceload remove -96 -288 96 -96
 
 # =============================================================================
 # STEP C — EAST OUTER SHELL EXPANSION (x=51..86, z=-100..-280)
@@ -364,7 +367,9 @@ fill 51 79 -111 86 79 -111 minecraft:sea_lantern
 fill 51 79 -107 86 79 -107 minecraft:sea_lantern
 fill 51 79 -103 86 79 -103 minecraft:sea_lantern
 
+forceload add -96 -288 96 -96
 fill 86 59 -280 86 82 -100 minecraft:white_concrete
+forceload remove -96 -288 96 -96
 
 # =============================================================================
 # STEP D — NORTH SPINE EXTENSION (x=-86..86, z=-280..-420)


### PR DESCRIPTION
Resolves [MIN-233](https://cirruslycloudy.com/MIN/issues/MIN-233)

## What

Adds `forceload add/remove` guards around the two narrow single-column outer wall fills in `f1_sprawl.mcfunction` Steps B and C:

- `fill -86 59 -280 -86 82 -100 minecraft:white_concrete` (west outer wall)
- `fill 86 59 -280 86 82 -100 minecraft:white_concrete` (east outer wall)

Both fills now run inside a `forceload add -96 -288 96 -96` / `forceload remove -96 -288 96 -96` pair.

## Why

Gate 2 QA (MIN-232) found x=±86, y=65–78, z≈-195..-280 were air. Root cause: the single-column fills ran when z≈-195..-280 chunks were unloaded. Minecraft silently skips fills into unloaded chunks; wider fills (floor/ceiling) loaded the chunks incidentally and succeeded, but the narrow wall fill did not.

## Scope

One file changed: `output/motfb-datapack/data/motfb/function/build/f1_sprawl.mcfunction`.
No other build functions touched.